### PR TITLE
Add a pull request template for Github

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 
 - [ ] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
 - [ ] I chose meaningful labels (if GitHub allows me to so).
-- [ ] I documented breaking changes and set the 'breaking change' label
+- [ ] I documented breaking changes and set the 'breaking change' label if needed
 - [ ] The implementation is complete.
 - [ ] Tests with a real hardware have been successful (or are not necessary).
 - [ ] Pytests have been added (or are not necessary).


### PR DESCRIPTION
I added our old pull request template and added "I documented breaking changes and set the 'breaking change' label if needed".
This provides a nice structure and better readability for pull requests