### PR TITLE
Fix ODrive reset button

### DIFF
--- a/feldfreund_devkit/hardware/tracks.py
+++ b/feldfreund_devkit/hardware/tracks.py
@@ -113,7 +113,7 @@ class TracksHardware(Wheels, ModuleHardware):
                 ui.label(f'L1: {"Error" if self._l1_error else "No error"}')
                 ui.label(f'R0: {"Error" if self._r0_error else "No error"}')
                 ui.label(f'R1: {"Error" if self._r1_error else "No error"}')
-            ui.button('Reset motor errors', on_click=self.reset_motors).set_enabled(not self.motor_error)
+            ui.button('Reset motor errors', on_click=self.reset_motors).set_enabled(self.motor_error)
 
         if self.config.odrive_version != self.ERROR_FLAG_VERSION:
             return


### PR DESCRIPTION
### Motivation & Implementation

The ODrive motor errors were only resetable via ui when there were no errors. That is fixed now.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] I documented breaking changes and set the 'breaking change' label if needed
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
