### PR TITLE
Add is_active setter to TargetLocator

### DIFF
--- a/feldfreund_devkit/target_locator.py
+++ b/feldfreund_devkit/target_locator.py
@@ -19,6 +19,13 @@ class TargetLocator(rosys.persistence.Persistable, ABC):
     def is_active(self) -> bool:
         return self._is_active
 
+    @is_active.setter
+    def is_active(self, active: bool) -> None:
+        if active:
+            self.resume()
+        else:
+            self.pause()
+
     def pause(self) -> None:
         if not self._is_active:
             return


### PR DESCRIPTION
### Motivation & Implementation

We were missing a setter for the `is_active` property of the `TargetLocator`. This makes it easier to use in the UI instead of using `resume` and `pause`.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] I documented breaking changes and set the 'breaking change' label if needed
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
