### PR TITLE
Fix publish workflow & add step to publish to pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,6 @@ jobs:
   docs:
     name: Build and publish docs
     runs-on: ubuntu-latest
-    needs: pypi
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,6 @@
 name: Publish release
 
 on:
-  workflow_dispatch:
   push:
     tags:
       - v**

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,56 @@ env:
   UV_NO_SOURCES: true
 
 jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+
+  pypi:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: get version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+      - name: build and publish
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          uv build
+          uv publish
+      - name: Fetch milestone notes
+        run: uv run fetch_milestone.py ${GITHUB_REF_NAME#v} > release_notes.md || true
+      - name: Create GitHub release entry
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          prerelease: false
+          name: ${{ env.VERSION }}
+          tag_name: ${{ env.VERSION }}
+          body_path: release_notes.md
+      - name: verify
+        shell: bash
+        run: |
+          for i in {1..100}; do
+            if python -m pip install "feldfreund_devkit==${VERSION#v}"; then
+              echo "Successfully installed feldfreund_devkit version ${VERSION#v}"
+              break
+            else
+              echo "Attempt $i failed. Retrying in 2 seconds..."
+              sleep 2
+            fi
+          done
+
+          if [ $i -eq 100 ]; then
+            echo "Failed to install feldfreund_devkit after 100 attempts"
+            exit 1
+          fi
+
   docs:
     name: Build and publish docs
     runs-on: ubuntu-latest
+    needs: pypi
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,15 +73,3 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4.7.3
         with:
           folder: site
-      - name: Fetch milestone notes
-        run: uv run fetch_milestone.py ${GITHUB_REF_NAME#v} > release_notes.md || true
-      - name: Create GitHub release entry
-        uses: softprops/action-gh-release@v2
-        with:
-          draft: true
-          prerelease: false
-          name: ${{ github.ref_name }}
-          tag_name: ${{ github.ref_name }}
-          body_path: release_notes.md
-        env:
-          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Run Tests
 
-on: [push]
+on: [push, workflow_call]
 
 env:
   UV_NO_SOURCES: true


### PR DESCRIPTION
### Motivation

The publish workflow referenced a non-existent `pypi` job, causing GitHub to reject it ("must contain at least one job with no dependencies"). We also want to actually publish to PyPI on release.

### Implementation

- Added a `pypi` job to the publish workflow that builds and publishes to PyPI via `uv build` / `uv publish`, creates a draft GitHub release with milestone notes, and verifies the package is installable from PyPI.
- Added a `test` job that reuses the existing test workflow as a prerequisite for publishing.
- Added `workflow_call` trigger to `test.yml` so it can be reused from the publish workflow.
- Job dependency chain: `test` → `pypi` → `docs`.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] I documented breaking changes and set the 'breaking change' label if needed
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).