### PR TITLE
Fix GNSS and IMU always being created in simulation

### DIFF
--- a/config/example.py
+++ b/config/example.py
@@ -6,6 +6,7 @@ from feldfreund_devkit.config import (
     FeldfreundConfiguration,
     FlashlightConfiguration,
     GnssConfiguration,
+    ImuConfiguration,
     RobotBrainConfiguration,
     TracksConfiguration,
 )
@@ -19,7 +20,7 @@ config = FeldfreundConfiguration(
     flashlight=FlashlightConfiguration(),
     gnss=GnssConfiguration(),
     implement=None,
-    imu=None,
+    imu=ImuConfiguration(),
     robot_brain=RobotBrainConfiguration(name='rbexample', nand=True),
     wheels=TracksConfiguration(is_left_reversed=True,
                                is_right_reversed=False,

--- a/feldfreund_devkit/feldfreund.py
+++ b/feldfreund_devkit/feldfreund.py
@@ -222,9 +222,7 @@ class FeldfreundSimulation(Feldfreund, RobotSimulation):
         bumper = BumperSimulation(estop=estop) if config.bumper else None
         bms = BmsSimulation(battery_low_threshold=config.bms.battery_low_threshold)
         imu = ImuSimulation(pose_provider=wheels) if config.imu else None
-        safety = SafetySimulation(wheels=wheels,
-                                  estop=estop,
-                                  bumper=bumper)
+        safety = SafetySimulation(wheels=wheels, estop=estop, bumper=bumper)
         gnss = GnssSimulation(pose_provider=wheels,
                               lat_std_dev=0.008,
                               lon_std_dev=0.008,

--- a/feldfreund_devkit/feldfreund.py
+++ b/feldfreund_devkit/feldfreund.py
@@ -221,11 +221,16 @@ class FeldfreundSimulation(Feldfreund, RobotSimulation):
         estop = EStopSimulation()
         bumper = BumperSimulation(estop=estop) if config.bumper else None
         bms = BmsSimulation(battery_low_threshold=config.bms.battery_low_threshold)
-        imu = ImuSimulation(pose_provider=wheels)
-        safety = SafetySimulation(wheels=wheels, estop=estop, bumper=bumper)
-        # NOTE: quick fix for https://github.com/zauberzeug/feldfreund/issues/348
-        gnss = GnssSimulation(pose_provider=wheels, lat_std_dev=1e-10, lon_std_dev=1e-10, heading_std_dev=1e-10) if rosys.is_test \
-            else GnssSimulation(pose_provider=wheels, lat_std_dev=0.008, lon_std_dev=0.008, heading_std_dev=0.01, interval=0.1, latency=0.1)
+        imu = ImuSimulation(pose_provider=wheels) if config.imu else None
+        safety = SafetySimulation(wheels=wheels,
+                                  estop=estop,
+                                  bumper=bumper)
+        gnss = GnssSimulation(pose_provider=wheels,
+                              lat_std_dev=0.008,
+                              lon_std_dev=0.008,
+                              heading_std_dev=0.01,
+                              interval=0.1,
+                              latency=0.1) if config.gnss else None
         modules = [wheels, flashlight, bumper, imu, bms, estop, safety]
         active_modules = [module for module in modules if module is not None]
         super().__init__(config,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,12 @@ class TestSystem(System):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         GeoReference.update_current(GEO_REFERENCE)
+        assert isinstance(self.feldfreund.gnss, GnssSimulation)
+        # NOTE: quick fix for https://github.com/zauberzeug/feldfreund/issues/348
+        self.feldfreund.gnss._lat_std_dev = 1e-10
+        self.feldfreund.gnss._lon_std_dev = 1e-10
+        self.feldfreund.gnss._heading_std_dev = 1e-10
+        self.feldfreund.gnss._latency = 0.0
         self.robot_locator = RobotLocator(self.feldfreund.wheels,
                                           gnss=self.feldfreund.gnss,
                                           imu=self.feldfreund.imu,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ class TestSystem(System):
         super().__init__(*args, **kwargs)
         GeoReference.update_current(GEO_REFERENCE)
         assert isinstance(self.feldfreund.gnss, GnssSimulation)
-        # NOTE: quick fix for https://github.com/zauberzeug/feldfreund/issues/348
+        # NOTE: we need low gnss noise for reliable tests
         self.feldfreund.gnss._lat_std_dev = 1e-10
         self.feldfreund.gnss._lon_std_dev = 1e-10
         self.feldfreund.gnss._heading_std_dev = 1e-10


### PR DESCRIPTION
### Motivation

GNSS and IMU simulations were always instantiated regardless of configuration, unlike other optional modules (flashlight, bumper) which already respected their config flags. This inconsistency meant simulations couldn't represent robots without these sensors.

### Implementation

- Make `ImuSimulation` and `GnssSimulation` conditional on `config.imu` and `config.gnss`, consistent with how `flashlight` and `bumper` are handled.
- Remove the `rosys.is_test` special case from `FeldfreundSimulation.__init__` — the simulation now always uses realistic noise parameters.
- Move the test-specific zero-noise GNSS overrides into `tests/conftest.py` where they belong.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).