### PR TITLE
Add skip_completed_segments utility to skip DriveSegments behind the robot

### DIFF
--- a/feldfreund_devkit/navigation/__init__.py
+++ b/feldfreund_devkit/navigation/__init__.py
@@ -1,14 +1,14 @@
 from .drive_segment import DriveSegment
 from .straight_line_navigation import StraightLineNavigation
-from .utils import filter_path_from_start_pose, generate_three_point_turn, is_reference_valid, sub_spline
+from .utils import generate_three_point_turn, is_reference_valid, skip_completed_segments, sub_spline
 from .waypoint_navigation import WaypointNavigation
 
 __all__ = [
     'DriveSegment',
     'StraightLineNavigation',
     'WaypointNavigation',
-    'filter_path_from_start_pose',
     'generate_three_point_turn',
     'is_reference_valid',
+    'skip_completed_segments',
     'sub_spline'
 ]

--- a/feldfreund_devkit/navigation/__init__.py
+++ b/feldfreund_devkit/navigation/__init__.py
@@ -1,12 +1,13 @@
 from .drive_segment import DriveSegment
 from .straight_line_navigation import StraightLineNavigation
-from .utils import generate_three_point_turn, is_reference_valid, sub_spline
+from .utils import filter_path_from_start_pose, generate_three_point_turn, is_reference_valid, sub_spline
 from .waypoint_navigation import WaypointNavigation
 
 __all__ = [
     'DriveSegment',
     'StraightLineNavigation',
     'WaypointNavigation',
+    'filter_path_from_start_pose',
     'generate_three_point_turn',
     'is_reference_valid',
     'sub_spline'

--- a/feldfreund_devkit/navigation/utils.py
+++ b/feldfreund_devkit/navigation/utils.py
@@ -3,6 +3,7 @@ import logging
 import numpy as np
 from rosys.geometry import GeoReference, Point, Pose, Spline
 from rosys.hardware import Gnss
+from rosys.helpers import angle
 
 from .drive_segment import DriveSegment
 
@@ -79,19 +80,23 @@ def filter_path_from_start_pose(start_pose: Pose,
     """Return the tail of ``path_segments`` starting at the segment the robot can pick up next.
 
     A segment is a candidate if it is not yet (almost) completed, the robot's heading
-    points toward its end within ``max_angle``, and the cross-track distance to its
-    spline is within ``max_distance``. Returns an empty list if no segment qualifies.
+    aligns with the spline tangent at the closest point within ``max_angle`` (flipped by
+    π for backward segments, since the robot faces opposite to its direction of travel),
+    and the cross-track distance to the spline is within ``max_distance``. Returns an
+    empty list if no segment qualifies.
     """
     log.debug('filter_path_from_start_pose: start=%s, %d segments, max_distance=%.2fm, max_angle=%.1f°',
               start_pose, len(path_segments), max_distance, np.rad2deg(max_angle))
     for i, segment in enumerate(path_segments):
+        # search slightly beyond [0, 1] so a robot just before/after the segment still maps cleanly
         t = segment.spline.closest_point(start_pose.x, start_pose.y, t_min=-0.1, t_max=1.1)
         if t > completed_threshold:
             log.debug('  segment %d rejected: completed (t=%.3f > %.2f)', i, t, completed_threshold)
             continue
-        heading_offset = start_pose.relative_direction(segment.end)
+        expected_yaw = segment.spline.yaw(t) + (np.pi if segment.backward else 0.0)
+        heading_offset = angle(start_pose.yaw, expected_yaw)
         if abs(heading_offset) > max_angle:
-            log.debug('  segment %d rejected: heading offset to end is %.1f° (max %.1f°)',
+            log.debug('  segment %d rejected: heading offset %.1f° (max %.1f°)',
                       i, np.rad2deg(heading_offset), np.rad2deg(max_angle))
             continue
         cross_track_distance = start_pose.distance(segment.spline.pose(t))
@@ -102,6 +107,6 @@ def filter_path_from_start_pose(start_pose: Pose,
         log.debug('  segment %d accepted (t=%.3f, heading offset=%.1f°, cross-track=%.2fm); returning %d segments',
                   i, t, np.rad2deg(heading_offset), cross_track_distance, len(path_segments) - i)
         return path_segments[i:]
-    log.warning('filter_path_from_start_pose: no segment matched from %s among %d candidates',
-                start_pose, len(path_segments))
+    log.debug('filter_path_from_start_pose: no segment matched from %s among %d candidates',
+              start_pose, len(path_segments))
     return []

--- a/feldfreund_devkit/navigation/utils.py
+++ b/feldfreund_devkit/navigation/utils.py
@@ -1,8 +1,13 @@
+import logging
+
 import numpy as np
 from rosys.geometry import GeoReference, Point, Pose, Spline
 from rosys.hardware import Gnss
 
 from .drive_segment import DriveSegment
+
+log = logging.getLogger('feldfreund.navigation')
+log.setLevel(logging.DEBUG)
 
 
 def is_reference_valid(gnss: Gnss | None, *, max_distance: float = 5000.0) -> bool:
@@ -65,3 +70,39 @@ def generate_three_point_turn(end_pose_current_row: Pose,
         DriveSegment.from_poses(first_turn_pose, back_up_pose, backward=backward, stop_at_end=backward),
         DriveSegment.from_poses(back_up_pose, start_pose_next_row),
     ]
+
+
+def filter_path_from_start_pose(start_pose: Pose,
+                                path_segments: list[DriveSegment], *,
+                                max_distance: float = 1.0,
+                                max_angle: float = np.deg2rad(45),
+                                completed_threshold: float = 0.99) -> list[DriveSegment]:
+    """Return the tail of ``path_segments`` starting at the segment the robot can pick up next.
+
+    A segment is a candidate if it is not yet (almost) completed, the robot's heading
+    points toward its end within ``max_angle``, and the cross-track distance to its
+    spline is within ``max_distance``. Returns an empty list if no segment qualifies.
+    """
+    log.debug('filter_path_from_start_pose: start=%s, %d segments, max_distance=%.2fm, max_angle=%.1f°',
+              start_pose, len(path_segments), max_distance, np.rad2deg(max_angle))
+    for i, segment in enumerate(path_segments):
+        t = segment.spline.closest_point(start_pose.x, start_pose.y, t_min=-0.1, t_max=1.1)
+        if t > completed_threshold:
+            log.debug('  segment %d rejected: completed (t=%.3f > %.2f)', i, t, completed_threshold)
+            continue
+        heading_offset = start_pose.relative_direction(segment.end)
+        if abs(heading_offset) > max_angle:
+            log.debug('  segment %d rejected: heading offset to end is %.1f° (max %.1f°)',
+                      i, np.rad2deg(heading_offset), np.rad2deg(max_angle))
+            continue
+        cross_track_distance = start_pose.distance(segment.spline.pose(t))
+        if cross_track_distance > max_distance:
+            log.debug('  segment %d rejected: cross-track distance %.2fm (max %.2fm)',
+                      i, cross_track_distance, max_distance)
+            continue
+        log.debug('  segment %d accepted (t=%.3f, heading offset=%.1f°, cross-track=%.2fm); returning %d segments',
+                  i, t, np.rad2deg(heading_offset), cross_track_distance, len(path_segments) - i)
+        return path_segments[i:]
+    log.warning('filter_path_from_start_pose: no segment matched from %s among %d candidates',
+                start_pose, len(path_segments))
+    return []

--- a/feldfreund_devkit/navigation/utils.py
+++ b/feldfreund_devkit/navigation/utils.py
@@ -72,11 +72,11 @@ def generate_three_point_turn(end_pose_current_row: Pose,
     ]
 
 
-def filter_path_from_start_pose(start_pose: Pose,
-                                path_segments: list[DriveSegment], *,
-                                max_distance: float = 1.0,
-                                max_angle: float = np.deg2rad(45),
-                                completed_threshold: float = 0.99) -> list[DriveSegment]:
+def skip_completed_segments(start_pose: Pose,
+                             path_segments: list[DriveSegment], *,
+                             max_distance: float = 1.0,
+                             max_angle: float = np.deg2rad(45),
+                             completed_threshold: float = 0.99) -> list[DriveSegment]:
     """Return the tail of ``path_segments`` starting at the segment the robot can pick up next.
 
     A segment is a candidate if it is not yet (almost) completed, the robot's heading
@@ -85,7 +85,7 @@ def filter_path_from_start_pose(start_pose: Pose,
     and the cross-track distance to the spline is within ``max_distance``. Returns an
     empty list if no segment qualifies.
     """
-    log.debug('filter_path_from_start_pose: start=%s, %d segments, max_distance=%.2fm, max_angle=%.1f°',
+    log.debug('skip_completed_segments: start=%s, %d segments, max_distance=%.2fm, max_angle=%.1f°',
               start_pose, len(path_segments), max_distance, np.rad2deg(max_angle))
     for i, segment in enumerate(path_segments):
         # search slightly beyond [0, 1] so a robot just before/after the segment still maps cleanly
@@ -107,6 +107,6 @@ def filter_path_from_start_pose(start_pose: Pose,
         log.debug('  segment %d accepted (t=%.3f, heading offset=%.1f°, cross-track=%.2fm); returning %d segments',
                   i, t, np.rad2deg(heading_offset), cross_track_distance, len(path_segments) - i)
         return path_segments[i:]
-    log.debug('filter_path_from_start_pose: no segment matched from %s among %d candidates',
+    log.debug('skip_completed_segments: no segment matched from %s among %d candidates',
               start_pose, len(path_segments))
     return []

--- a/feldfreund_devkit/navigation/utils.py
+++ b/feldfreund_devkit/navigation/utils.py
@@ -7,7 +7,6 @@ from rosys.hardware import Gnss
 from .drive_segment import DriveSegment
 
 log = logging.getLogger('feldfreund.navigation')
-log.setLevel(logging.DEBUG)
 
 
 def is_reference_valid(gnss: Gnss | None, *, max_distance: float = 5000.0) -> bool:

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -6,7 +6,7 @@ from rosys.helpers import angle
 from rosys.testing import assert_point, forward
 
 from feldfreund_devkit.hardware.tracks import TracksSimulation
-from feldfreund_devkit.navigation import DriveSegment, StraightLineNavigation
+from feldfreund_devkit.navigation import DriveSegment, StraightLineNavigation, filter_path_from_start_pose
 
 
 @pytest.mark.parametrize('distance', (0.005, 0.01, 0.05, 0.1, 0.5, 1.0))
@@ -130,9 +130,9 @@ async def test_start_on_end(devkit_system):
 
 
 async def test_skip_first_segment(devkit_system):
-    pose1 = Pose(x=-1, y=1, yaw=-np.pi/2)
+    pose1 = Pose(x=-1, y=1, yaw=-np.pi / 2)
     pose2 = Pose(x=0, y=0.0, yaw=0.0)
-    pose3 = Pose(x=1.0, y=1.0, yaw=np.pi/2)
+    pose3 = Pose(x=1.0, y=1.0, yaw=np.pi / 2)
     pose4 = Pose(x=0, y=2.0, yaw=np.pi)
     assert isinstance(devkit_system.current_navigation, StraightLineNavigation)
 
@@ -154,3 +154,35 @@ async def test_skip_first_segment(devkit_system):
     assert devkit_system.current_navigation.current_segment.end.x == pytest.approx(pose3.x, abs=0.1)
     assert devkit_system.current_navigation.current_segment.end.y == pytest.approx(pose3.y, abs=0.1)
     assert devkit_system.current_navigation.current_segment.end.yaw_deg == pytest.approx(pose3.yaw_deg, abs=0.1)
+
+
+@pytest.mark.parametrize(('robot_x', 'robot_yaw_deg', 'expected_count', 'expected_start_x'), [
+    (0.0, 0, 3, 0.0),  # at start of first segment, facing forward
+    (0.5, 0, 3, 0.0),  # on first segment, facing forward
+    (1.2, 0, 2, 1.0),  # on second segment, facing forward
+    (2.5, 0, 1, 2.0),  # on third segment, facing forward
+    (1.2, 30, 2, 1.0),  # on second segment, heading offset within tolerance
+    (1.2, 60, 0, None),  # heading offset exceeds default 45° tolerance
+    (1.2, 180, 0, None),  # facing backward, no segment is reachable
+])
+def test_filter_path_from_start_pose(robot_x: float,
+                                     robot_yaw_deg: float,
+                                     expected_count: int,
+                                     expected_start_x: float | None):
+    pose0 = Pose(x=0.0, y=0.0, yaw=0.0)
+    pose1 = Pose(x=1.0, y=0.0, yaw=0.0)
+    pose2 = Pose(x=2.0, y=0.0, yaw=0.0)
+    pose3 = Pose(x=3.0, y=0.0, yaw=0.0)
+    path = [
+        DriveSegment.from_poses(pose0, pose1),
+        DriveSegment.from_poses(pose1, pose2),
+        DriveSegment.from_poses(pose2, pose3),
+    ]
+    robot_pose = Pose(x=robot_x, y=0.0, yaw=np.deg2rad(robot_yaw_deg))
+    result = filter_path_from_start_pose(robot_pose, path)
+    assert len(result) == expected_count
+    if expected_count > 0:
+        assert expected_start_x is not None
+        assert result[0].start.x == pytest.approx(expected_start_x)
+        assert result[0].start.y == pytest.approx(0.0)
+        assert result[-1].end.x == pytest.approx(pose3.x)

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -6,7 +6,7 @@ from rosys.helpers import angle
 from rosys.testing import assert_point, forward
 
 from feldfreund_devkit.hardware.tracks import TracksSimulation
-from feldfreund_devkit.navigation import DriveSegment, StraightLineNavigation, filter_path_from_start_pose
+from feldfreund_devkit.navigation import DriveSegment, StraightLineNavigation, skip_completed_segments
 
 
 @pytest.mark.parametrize('distance', (0.005, 0.01, 0.05, 0.1, 0.5, 1.0))
@@ -165,10 +165,10 @@ async def test_skip_first_segment(devkit_system):
     (1.2, 60, 0, None),  # heading offset exceeds default 45° tolerance
     (1.2, 180, 0, None),  # facing backward, no segment is reachable
 ])
-def test_filter_path_from_start_pose(robot_x: float,
-                                     robot_yaw_deg: float,
-                                     expected_count: int,
-                                     expected_start_x: float | None):
+def test_skip_completed_segments(robot_x: float,
+                                 robot_yaw_deg: float,
+                                 expected_count: int,
+                                 expected_start_x: float | None):
     pose0 = Pose(x=0.0, y=0.0, yaw=0.0)
     pose1 = Pose(x=1.0, y=0.0, yaw=0.0)
     pose2 = Pose(x=2.0, y=0.0, yaw=0.0)
@@ -179,7 +179,7 @@ def test_filter_path_from_start_pose(robot_x: float,
         DriveSegment.from_poses(pose2, pose3),
     ]
     robot_pose = Pose(x=robot_x, y=0.0, yaw=np.deg2rad(robot_yaw_deg))
-    result = filter_path_from_start_pose(robot_pose, path)
+    result = skip_completed_segments(robot_pose, path)
     assert len(result) == expected_count
     if expected_count > 0:
         assert expected_start_x is not None
@@ -188,29 +188,29 @@ def test_filter_path_from_start_pose(robot_x: float,
         assert result[-1].end.x == pytest.approx(pose3.x)
 
 
-def test_filter_path_picks_up_backward_segment():
+def test_skip_completed_segments_picks_up_backward_segment():
     # robot drives backward from x=2 to x=1 (still facing +x), then forward from x=1 to x=3
     path = [
         DriveSegment.from_poses(Pose(x=2.0, y=0.0, yaw=0.0), Pose(x=1.0, y=0.0, yaw=0.0), backward=True),
         DriveSegment.from_poses(Pose(x=1.0, y=0.0, yaw=0.0), Pose(x=3.0, y=0.0, yaw=0.0)),
     ]
     # robot mid-backward-segment, correctly facing +x → must accept the backward segment
-    result = filter_path_from_start_pose(Pose(x=1.5, y=0.0, yaw=0.0), path)
+    result = skip_completed_segments(Pose(x=1.5, y=0.0, yaw=0.0), path)
     assert len(result) == 2
     assert result[0].backward is True
 
     # same position but facing -x → wrong way for the backward leg AND for the forward continuation
-    result = filter_path_from_start_pose(Pose(x=1.5, y=0.0, yaw=np.pi), path)
+    result = skip_completed_segments(Pose(x=1.5, y=0.0, yaw=np.pi), path)
     assert result == []
 
 
-def test_filter_path_handles_segment_seam():
+def test_skip_completed_segments_handles_segment_seam():
     # robot near the very end of segment 0 must continue from segment 1, not redrive segment 0
     path = [
         DriveSegment.from_poses(Pose(x=0.0, y=0.0, yaw=0.0), Pose(x=1.0, y=0.0, yaw=0.0)),
         DriveSegment.from_poses(Pose(x=1.0, y=0.0, yaw=0.0), Pose(x=2.0, y=0.0, yaw=0.0)),
         DriveSegment.from_poses(Pose(x=2.0, y=0.0, yaw=0.0), Pose(x=3.0, y=0.0, yaw=0.0)),
     ]
-    result = filter_path_from_start_pose(Pose(x=0.999, y=0.0, yaw=0.0), path)
+    result = skip_completed_segments(Pose(x=0.999, y=0.0, yaw=0.0), path)
     assert len(result) == 2
     assert result[0].start.x == pytest.approx(1.0)

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -186,3 +186,31 @@ def test_filter_path_from_start_pose(robot_x: float,
         assert result[0].start.x == pytest.approx(expected_start_x)
         assert result[0].start.y == pytest.approx(0.0)
         assert result[-1].end.x == pytest.approx(pose3.x)
+
+
+def test_filter_path_picks_up_backward_segment():
+    # robot drives backward from x=2 to x=1 (still facing +x), then forward from x=1 to x=3
+    path = [
+        DriveSegment.from_poses(Pose(x=2.0, y=0.0, yaw=0.0), Pose(x=1.0, y=0.0, yaw=0.0), backward=True),
+        DriveSegment.from_poses(Pose(x=1.0, y=0.0, yaw=0.0), Pose(x=3.0, y=0.0, yaw=0.0)),
+    ]
+    # robot mid-backward-segment, correctly facing +x → must accept the backward segment
+    result = filter_path_from_start_pose(Pose(x=1.5, y=0.0, yaw=0.0), path)
+    assert len(result) == 2
+    assert result[0].backward is True
+
+    # same position but facing -x → wrong way for the backward leg AND for the forward continuation
+    result = filter_path_from_start_pose(Pose(x=1.5, y=0.0, yaw=np.pi), path)
+    assert result == []
+
+
+def test_filter_path_handles_segment_seam():
+    # robot near the very end of segment 0 must continue from segment 1, not redrive segment 0
+    path = [
+        DriveSegment.from_poses(Pose(x=0.0, y=0.0, yaw=0.0), Pose(x=1.0, y=0.0, yaw=0.0)),
+        DriveSegment.from_poses(Pose(x=1.0, y=0.0, yaw=0.0), Pose(x=2.0, y=0.0, yaw=0.0)),
+        DriveSegment.from_poses(Pose(x=2.0, y=0.0, yaw=0.0), Pose(x=3.0, y=0.0, yaw=0.0)),
+    ]
+    result = filter_path_from_start_pose(Pose(x=0.999, y=0.0, yaw=0.0), path)
+    assert len(result) == 2
+    assert result[0].start.x == pytest.approx(1.0)


### PR DESCRIPTION
### Motivation

When a path is handed to navigation but the robot is already past some of its segments, those segments need to be dropped before driving — otherwise the robot turns around and re-drives completed work.

### Implementation

Walk `path_segments` and return the tail starting at the first segment the robot is on (cross-track within `max_distance`, heading offset to the segment end within `max_angle`) and not yet completed (`t ≤ completed_threshold`); return `[]` if none qualify.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] I documented breaking changes and set the 'breaking change' label if needed
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
