### PR TITLE
Let the flashlight respect `on_expander` and expose LEDC channels

### DIFF
--- a/feldfreund_devkit/config/flashlight_configuration.py
+++ b/feldfreund_devkit/config/flashlight_configuration.py
@@ -43,23 +43,13 @@ class FlashlightConfiguration:
 class FlashlightMosfetConfiguration:
     """Configuration for the mosfet based flashlight of the Feldfreund robot.
 
-    The LEDC channel must not collide with other PwmOutputs on the same chip.
+    Deprecated: only used on U4. Not built into any new robot; do not extend.
 
     Defaults:
         name: str = 'flashlight_mosfet'
         on_expander: True
         pin: 2
-        ledc_timer: 0
-        ledc_channel: 0
     """
     name: str = 'flashlight_mosfet'
     on_expander: bool = True
     pin: int = 2
-    ledc_timer: int = 0
-    ledc_channel: int = 0
-
-    def __post_init__(self) -> None:
-        if not 0 <= self.ledc_timer <= 3:
-            raise ValueError('ledc_timer must be between 0 and 3')
-        if not 0 <= self.ledc_channel <= 15:
-            raise ValueError('ledc_channel must be between 0 and 15')

--- a/feldfreund_devkit/config/flashlight_configuration.py
+++ b/feldfreund_devkit/config/flashlight_configuration.py
@@ -26,6 +26,17 @@ class FlashlightConfiguration:
     back_ledc_channel: int = 1
     duty_cycle: float = 1.0
 
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.duty_cycle <= 1.0:
+            raise ValueError('duty_cycle must be between 0 and 1')
+        if not 0 <= self.ledc_timer <= 3:
+            raise ValueError('ledc_timer must be between 0 and 3')
+        for channel in (self.front_ledc_channel, self.back_ledc_channel):
+            if not 0 <= channel <= 15:
+                raise ValueError('LEDC channel must be between 0 and 15')
+        if self.front_ledc_channel == self.back_ledc_channel:
+            raise ValueError('front_ledc_channel and back_ledc_channel must differ')
+
 
 @dataclass(slots=True, kw_only=True)
 class FlashlightMosfetConfiguration:

--- a/feldfreund_devkit/config/flashlight_configuration.py
+++ b/feldfreund_devkit/config/flashlight_configuration.py
@@ -31,9 +31,10 @@ class FlashlightConfiguration:
             raise ValueError('duty_cycle must be between 0 and 1')
         if not 0 <= self.ledc_timer <= 3:
             raise ValueError('ledc_timer must be between 0 and 3')
-        for channel in (self.front_ledc_channel, self.back_ledc_channel):
-            if not 0 <= channel <= 15:
-                raise ValueError('LEDC channel must be between 0 and 15')
+        if not 0 <= self.front_ledc_channel <= 15:
+            raise ValueError('front_ledc_channel must be between 0 and 15')
+        if not 0 <= self.back_ledc_channel <= 15:
+            raise ValueError('back_ledc_channel must be between 0 and 15')
         if self.front_ledc_channel == self.back_ledc_channel:
             raise ValueError('front_ledc_channel and back_ledc_channel must differ')
 
@@ -42,11 +43,23 @@ class FlashlightConfiguration:
 class FlashlightMosfetConfiguration:
     """Configuration for the mosfet based flashlight of the Feldfreund robot.
 
+    The LEDC channel must not collide with other PwmOutputs on the same chip.
+
     Defaults:
         name: str = 'flashlight_mosfet'
         on_expander: True
         pin: 2
+        ledc_timer: 0
+        ledc_channel: 0
     """
     name: str = 'flashlight_mosfet'
     on_expander: bool = True
     pin: int = 2
+    ledc_timer: int = 0
+    ledc_channel: int = 0
+
+    def __post_init__(self) -> None:
+        if not 0 <= self.ledc_timer <= 3:
+            raise ValueError('ledc_timer must be between 0 and 3')
+        if not 0 <= self.ledc_channel <= 15:
+            raise ValueError('ledc_channel must be between 0 and 15')

--- a/feldfreund_devkit/config/flashlight_configuration.py
+++ b/feldfreund_devkit/config/flashlight_configuration.py
@@ -5,16 +5,26 @@ from dataclasses import dataclass
 class FlashlightConfiguration:
     """Configuration for the flashlight of the Feldfreund robot.
 
+    The LEDC channels must not collide with other PwmOutputs on the same chip.
+
     Defaults:
         name: 'flashlight'
         on_expander: True
         front_pin: 12
         back_pin: 23
+        ledc_timer: 0
+        front_ledc_channel: 0
+        back_ledc_channel: 1
+        duty_cycle: 1.0
     """
     name: str = 'flashlight'
     on_expander: bool = True
     front_pin: int = 12
     back_pin: int = 23
+    ledc_timer: int = 0
+    front_ledc_channel: int = 0
+    back_ledc_channel: int = 1
+    duty_cycle: float = 1.0
 
 
 @dataclass(slots=True, kw_only=True)

--- a/feldfreund_devkit/hardware/flashlight.py
+++ b/feldfreund_devkit/hardware/flashlight.py
@@ -123,7 +123,10 @@ class FlashlightHardware(Flashlight, rosys.hardware.ModuleHardware, SafetyMixin)
 
 
 class FlashlightHardwareMosfet(Flashlight, rosys.hardware.ModuleHardware, SafetyMixin):
-    """Flashlight hardware implementation using a MOSFET switch."""
+    """Flashlight hardware implementation using a MOSFET switch.
+
+    Deprecated: only used on U4. Not built into any new robot; do not extend.
+    """
 
     UPDATE_INTERVAL = 5.0
 
@@ -136,7 +139,7 @@ class FlashlightHardwareMosfet(Flashlight, rosys.hardware.ModuleHardware, Safety
         self.bms = bms
         prefix = f'{expander.name}.' if expander is not None and config.on_expander else ''
         lizard_code = remove_indentation(f'''
-            {config.name} = {prefix}PwmOutput({config.pin}, {config.ledc_timer}, {config.ledc_channel})
+            {config.name} = {prefix}PwmOutput({config.pin})
             {config.name}.duty = 204
         ''')
         # NOTE: Electronically the duty cycle should be variable based on the battery voltage, but 204 has been tested extensively and works well.

--- a/feldfreund_devkit/hardware/flashlight.py
+++ b/feldfreund_devkit/hardware/flashlight.py
@@ -61,14 +61,17 @@ class FlashlightHardware(Flashlight, rosys.hardware.ModuleHardware, SafetyMixin)
                  expander: rosys.hardware.ExpanderHardware | None) -> None:
         self.config = config
         self.expander = expander
+        prefix = f'{expander.name}.' if expander is not None and config.on_expander else ''
+        duty = self._convert_duty_cycle_to_8_bit(config.duty_cycle)
         lizard_code = remove_indentation(f'''
-            {config.name}_front = {expander.name + "." if expander else ""}PwmOutput({config.front_pin})
-            {config.name}_front.duty = 255
-            {config.name}_back = {expander.name + "." if expander else ""}PwmOutput({config.back_pin})
-            {config.name}_back.duty = 255
+            {config.name}_front = {prefix}PwmOutput({config.front_pin}, {config.ledc_timer}, {config.front_ledc_channel})
+            {config.name}_front.duty = {duty}
+            {config.name}_back = {prefix}PwmOutput({config.back_pin}, {config.ledc_timer}, {config.back_ledc_channel})
+            {config.name}_back.duty = {duty}
             {config.name}_front.shadow({config.name}_back)
         ''')
         super().__init__(robot_brain=robot_brain, lizard_code=lizard_code)
+        self._duty_cycle = config.duty_cycle
 
     @property
     def enable_code(self) -> str:

--- a/feldfreund_devkit/hardware/flashlight.py
+++ b/feldfreund_devkit/hardware/flashlight.py
@@ -134,8 +134,9 @@ class FlashlightHardwareMosfet(Flashlight, rosys.hardware.ModuleHardware, Safety
         self.config = config
         self.expander = expander
         self.bms = bms
+        prefix = f'{expander.name}.' if expander is not None and config.on_expander else ''
         lizard_code = remove_indentation(f'''
-            {config.name} = {expander.name + "." if expander else ""}PwmOutput({config.pin})
+            {config.name} = {prefix}PwmOutput({config.pin})
             {config.name}.duty = 204
         ''')
         # NOTE: Electronically the duty cycle should be variable based on the battery voltage, but 204 has been tested extensively and works well.

--- a/feldfreund_devkit/hardware/flashlight.py
+++ b/feldfreund_devkit/hardware/flashlight.py
@@ -81,7 +81,8 @@ class FlashlightHardware(Flashlight, rosys.hardware.ModuleHardware, SafetyMixin)
     def disable_code(self) -> str:
         return f'{self.config.name}_front.disable(); {self.config.name}_back.disable();'
 
-    def _convert_duty_cycle_to_8_bit(self, duty_cycle: float) -> int:
+    @staticmethod
+    def _convert_duty_cycle_to_8_bit(duty_cycle: float) -> int:
         """Convert the duty cycle to a 8 bit value (0-255).
 
         :param duty_cycle: float between 0 and 1

--- a/feldfreund_devkit/hardware/flashlight.py
+++ b/feldfreund_devkit/hardware/flashlight.py
@@ -136,7 +136,7 @@ class FlashlightHardwareMosfet(Flashlight, rosys.hardware.ModuleHardware, Safety
         self.bms = bms
         prefix = f'{expander.name}.' if expander is not None and config.on_expander else ''
         lizard_code = remove_indentation(f'''
-            {config.name} = {prefix}PwmOutput({config.pin})
+            {config.name} = {prefix}PwmOutput({config.pin}, {config.ledc_timer}, {config.ledc_channel})
             {config.name}.duty = 204
         ''')
         # NOTE: Electronically the duty cycle should be variable based on the battery voltage, but 204 has been tested extensively and works well.


### PR DESCRIPTION
### Motivation

`FlashlightHardware` ignored `on_expander` and prefixed the Lizard `PwmOutput` with the expander name whenever an expander was passed, regardless of the flag.
It also hard-coded the LEDC channel allocation, which can collide with other `PwmOutput`s on the same chip — see #33.

### Implementation

- Respect `on_expander`: the expander prefix is only applied when both an expander is present *and* `config.on_expander` is true.
- Make LEDC allocation explicit: expose `ledc_timer`, `front_ledc_channel`, `back_ledc_channel` on `FlashlightConfiguration` and pass them as the second/third argument to `PwmOutput(...)`.
  Defaults match the previous implicit allocation (timer 0, channels 0/1).
- Make brightness configurable via `duty_cycle` (0.0–1.0), converted to the 8-bit Lizard duty value; previous behavior (full brightness) is preserved as the default.

A docstring note reminds users that the LEDC channels must not collide with other `PwmOutput`s on the same chip.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] I documented breaking changes and set the 'breaking change' label if needed
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
