### PR TITLE
Update motor driver creation

### DIFF
--- a/feldfreund_devkit/hardware/tracks.py
+++ b/feldfreund_devkit/hardware/tracks.py
@@ -167,11 +167,19 @@ class InnotronicTracksHardware(TracksHardware):
             {config.name} = InnotronicWheels(left, right)
             {config.name}.width = {config.width}
         ''')
-        core_message_fields = [f'{config.name}.linear_speed:3', f'{config.name}.angular_speed:3']
+        core_message_fields = [
+            f'{config.name}.linear_speed:3', f'{config.name}.angular_speed:3',
+            'left.current_m1:3', 'left.current_m2:3',
+            'right.current_m1:3', 'right.current_m2:3',
+        ]
         super().__init__(config, robot_brain, lizard_code=lizard_code, core_message_fields=core_message_fields)
 
     def handle_core_output(self, time: float, words: list[str]) -> None:
         velocity = Velocity(linear=float(words.pop(0)), angular=float(words.pop(0)), time=time)
+        self.left_current_m1 = float(words.pop(0))
+        self.left_current_m2 = float(words.pop(0))
+        self.right_current_m1 = float(words.pop(0))
+        self.right_current_m2 = float(words.pop(0))
         if abs(velocity.linear) <= self.MAX_VALID_LINEAR_VELOCITY and abs(velocity.angular) <= self.MAX_VALID_ANGULAR_VELOCITY:
             self.VELOCITY_MEASURED.emit([velocity])
         else:

--- a/feldfreund_devkit/hardware/tracks.py
+++ b/feldfreund_devkit/hardware/tracks.py
@@ -158,10 +158,8 @@ class InnotronicTracksHardware(TracksHardware):
                  robot_brain: RobotBrain, *,
                  can: CanHardware) -> None:
         lizard_code = remove_indentation(f'''
-            left = InnotronicMotor({can.name}, {config.left_can_address})
-            right = InnotronicMotor({can.name}, {config.right_can_address})
-            left.switch_to_drive_mode()
-            right.switch_to_drive_mode()
+            left = InnotronicDriveMotor({can.name}, {config.left_can_address})
+            right = InnotronicDriveMotor({can.name}, {config.right_can_address})
             left.reversed = {'true' if config.is_left_reversed else 'false'}
             right.reversed = {'true' if config.is_right_reversed else 'false'}
             left.m_per_rad = {config.m_per_rad}

--- a/feldfreund_devkit/hardware/tracks.py
+++ b/feldfreund_devkit/hardware/tracks.py
@@ -171,6 +171,7 @@ class InnotronicTracksHardware(TracksHardware):
             f'{config.name}.linear_speed:3', f'{config.name}.angular_speed:3',
             'left.current_m1:3', 'left.current_m2:3',
             'right.current_m1:3', 'right.current_m2:3',
+            'right.speed:3', 'left.speed:3',
         ]
         super().__init__(config, robot_brain, lizard_code=lizard_code, core_message_fields=core_message_fields)
 
@@ -180,6 +181,8 @@ class InnotronicTracksHardware(TracksHardware):
         self.left_current_m2 = float(words.pop(0))
         self.right_current_m1 = float(words.pop(0))
         self.right_current_m2 = float(words.pop(0))
+        self.left_speed = float(words.pop(0))
+        self.right_speed = float(words.pop(0))
         if abs(velocity.linear) <= self.MAX_VALID_LINEAR_VELOCITY and abs(velocity.angular) <= self.MAX_VALID_ANGULAR_VELOCITY:
             self.VELOCITY_MEASURED.emit([velocity])
         else:


### PR DESCRIPTION
### Motivation

Adapt to the updated Lizard `InnotronicDriveMotor` module. In addition, motor currents are now included in the core output so that current monitoring and debugging are possible at the application level.

### Implementation

- `InnotronicTracksHardware` updated to the new Lizard module signature (construction via `InnotronicDriveMotor(can, node_id)` and `InnotronicWheels`).
- `core_message_fields` extended with `left.current_m1`, `left.current_m2`, `right.current_m1`, `right.current_m2` (4 values, 2 per side — the Innotronic driver reports the current of motor 1 and motor 2 per module in amperes).
- `handle_core_output` stores the four current values in `left_current_m1`, `left_current_m2`, `right_current_m1`, `right_current_m2`.

### Note / Follow-ups

If further values from the Lizard module are needed (e.g. status flags, temperatures, position ticks), they have to be added analogously in `core_message_fields` and `handle_core_output`. For now only the currents are exposed — sufficient for initial logging/debugging; more can be added on demand.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] I documented breaking changes and set the 'breaking change' label if needed
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).