### PR TITLE
Attach camera pose to image metadata

### DIFF
--- a/feldfreund_devkit/__init__.py
+++ b/feldfreund_devkit/__init__.py
@@ -1,5 +1,5 @@
 from . import log_configuration
-from .camera_provider import CameraProvider
+from .camera_provider import CameraProvider, PoseMetadataMixin
 from .feldfreund import Feldfreund, FeldfreundHardware, FeldfreundSimulation
 from .implement import Implement, ImplementDummy, ImplementException
 from .robot_locator import RobotLocator
@@ -15,6 +15,7 @@ __all__ = [
     'Implement',
     'ImplementDummy',
     'ImplementException',
+    'PoseMetadataMixin',
     'RobotLocator',
     'System',
     'TargetLocator',

--- a/feldfreund_devkit/camera_provider.py
+++ b/feldfreund_devkit/camera_provider.py
@@ -5,7 +5,7 @@ from typing import Literal
 
 import rosys
 from nicegui import ui
-from rosys.geometry import FrameProvider
+from rosys.geometry import FrameProvider, Pose3d, Rotation
 from rosys.vision import CalibratableCamera
 from rosys.vision.mjpeg_camera.vendors import VendorType as MjpegVendorType
 from rosys.vision.mjpeg_camera.vendors import mac_to_vendor as mjpeg_mac_to_vendor
@@ -23,15 +23,30 @@ from .config import (
 from .interface.components import status_bulb
 
 
-class CalibratableUsbCamera(rosys.vision.CalibratableCamera, rosys.vision.UsbCamera):
+class _PoseMetadataMixin(rosys.vision.CalibratableCamera):
+    """Attaches the resolved camera pose to each captured image's metadata."""
+
+    def _add_image(self, image: rosys.vision.Image) -> None:
+        if self.calibration is not None:
+            pose = self.calibration.extrinsics.resolve()
+            image.metadata['pose'] = Pose3d(x=pose.x, y=pose.y, z=pose.z,
+                                            rotation=Rotation(R=[row[:] for row in pose.rotation.R]))
+        super()._add_image(image)
+
+
+class CalibratableUsbCamera(_PoseMetadataMixin, rosys.vision.UsbCamera):
     pass
 
 
-class CalibratableRtspCamera(rosys.vision.CalibratableCamera, rosys.vision.RtspCamera):
+class CalibratableRtspCamera(_PoseMetadataMixin, rosys.vision.RtspCamera):
     pass
 
 
-class CalibratableMjpegCamera(rosys.vision.CalibratableCamera, rosys.vision.MjpegCamera):
+class CalibratableMjpegCamera(_PoseMetadataMixin, rosys.vision.MjpegCamera):
+    pass
+
+
+class SimulatedCalibratableCamera(_PoseMetadataMixin, rosys.vision.SimulatedCalibratableCamera):
     pass
 
 
@@ -114,7 +129,7 @@ class CameraProvider:
         """Create a camera based on the given slot configuration."""
         camera: rosys.vision.CalibratableCamera
         if rosys.is_simulation():
-            camera = rosys.vision.SimulatedCalibratableCamera(
+            camera = SimulatedCalibratableCamera(
                 id=slot.camera_id,
                 width=slot.width,
                 height=slot.height,

--- a/feldfreund_devkit/camera_provider.py
+++ b/feldfreund_devkit/camera_provider.py
@@ -46,7 +46,7 @@ class CalibratableMjpegCamera(_PoseMetadataMixin, rosys.vision.MjpegCamera):
     pass
 
 
-class SimulatedCalibratableCamera(_PoseMetadataMixin, rosys.vision.SimulatedCalibratableCamera):
+class SimulatedCalibratableCamera(_PoseMetadataMixin, rosys.vision.SimulatedCalibratableCamera):  # pylint: disable=too-many-ancestors
     pass
 
 

--- a/feldfreund_devkit/camera_provider.py
+++ b/feldfreund_devkit/camera_provider.py
@@ -23,7 +23,7 @@ from .config import (
 from .interface.components import status_bulb
 
 
-class _PoseMetadataMixin(rosys.vision.CalibratableCamera):
+class PoseMetadataMixin(rosys.vision.CalibratableCamera):
     """Attaches the resolved camera pose to each captured image's metadata."""
 
     def _add_image(self, image: rosys.vision.Image) -> None:
@@ -34,19 +34,19 @@ class _PoseMetadataMixin(rosys.vision.CalibratableCamera):
         super()._add_image(image)
 
 
-class CalibratableUsbCamera(_PoseMetadataMixin, rosys.vision.UsbCamera):
+class CalibratableUsbCamera(PoseMetadataMixin, rosys.vision.UsbCamera):
     pass
 
 
-class CalibratableRtspCamera(_PoseMetadataMixin, rosys.vision.RtspCamera):
+class CalibratableRtspCamera(PoseMetadataMixin, rosys.vision.RtspCamera):
     pass
 
 
-class CalibratableMjpegCamera(_PoseMetadataMixin, rosys.vision.MjpegCamera):
+class CalibratableMjpegCamera(PoseMetadataMixin, rosys.vision.MjpegCamera):
     pass
 
 
-class SimulatedCalibratableCamera(_PoseMetadataMixin, rosys.vision.SimulatedCalibratableCamera):  # pylint: disable=too-many-ancestors
+class SimulatedCalibratableCamera(PoseMetadataMixin, rosys.vision.SimulatedCalibratableCamera):  # pylint: disable=too-many-ancestors
     pass
 
 


### PR DESCRIPTION
### Motivation

Downstream consumers of camera images (e.g., detection-to-frame projection) need the camera pose at capture time.

### Implementation

A new `_PoseMetadataMixin`overrides `_add_image` to snapshot the resolved extrinsic pose into `image.metadata['pose']`. The pose is deep-copied.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] I documented breaking changes and set the 'breaking change' label if needed
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).