### PR TITLE
Fix crash when logging the deprecated ODrive firmware warning

### DIFF
--- a/feldfreund_devkit/hardware/tracks.py
+++ b/feldfreund_devkit/hardware/tracks.py
@@ -85,9 +85,9 @@ class ODriveTracksHardware(TracksHardware):
         if config.odrive_version == self.ERROR_FLAG_VERSION:
             core_message_fields.extend(['l0.motor_error_flag', 'r0.motor_error_flag',
                                        'l1.motor_error_flag', 'r1.motor_error_flag'])
-        else:
-            self.log.warning('ODrive firmware is deprecated. Please update to benefit from the motor error detection.')
         super().__init__(config, robot_brain, lizard_code=lizard_code, core_message_fields=core_message_fields)
+        if config.odrive_version != self.ERROR_FLAG_VERSION:
+            self.log.warning('ODrive firmware is deprecated. Please update to benefit from the motor error detection.')
 
     @property
     def motor_error(self) -> bool:


### PR DESCRIPTION
### Motivation

Initializing `ODriveTracksHardware` with a deprecated ODrive firmware version (`odrive_version != 6`) crashed with an `AttributeError`, because the deprecation warning used `self.log` before it exists.

### Implementation

- Move the deprecation warning in `ODriveTracksHardware.__init__` after the `super().__init__()` call, since `self.log` is only set in `rosys.hardware.Module.__init__`

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] I documented breaking changes and set the 'breaking change' label if needed
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

---
⬛ claude-fable-5