### PR TITLE
Keep the EKF covariance positive semi-definite (Joseph form)

### DIFF
--- a/feldfreund_devkit/robot_locator.py
+++ b/feldfreund_devkit/robot_locator.py
@@ -35,8 +35,8 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider):
         self._gnss_config = gnss_config
 
         state_size = 3
-        self._x = np.zeros((state_size, 1))
-        self._Sxx = np.zeros((state_size, state_size))
+        self._x: np.ndarray = np.zeros((state_size, 1))
+        self._Sxx: np.ndarray = np.zeros((state_size, state_size))
         self._pose_timestamp = rosys.time()
         # NOTE: the prediction step needs to be run once before the first GNSS update
         self._first_prediction_done = False
@@ -209,7 +209,11 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider):
             L = np.linalg.cholesky(S)
             K = self._Sxx @ H.T @ np.linalg.solve(L.T, np.linalg.solve(L, np.eye(S.shape[0])))
         self._x = self._x + K @ (z - h)
-        self._Sxx = (np.eye(self._Sxx.shape[0]) - K @ H) @ self._Sxx
+        # Joseph form keeps the covariance symmetric and positive semi-definite, unlike the
+        # naive (I - K H) P which drifts into asymmetry and negative eigenvalues (#348, #372)
+        A = np.eye(self._Sxx.shape[0]) - K @ H
+        self._Sxx = A @ self._Sxx @ A.T + K @ Q @ K.T
+        self._Sxx = (self._Sxx + self._Sxx.T) / 2  # remove residual asymmetry from floating-point error
         self._update_frame()
 
     def _update_frame(self) -> None:

--- a/tests/test_robot_locator.py
+++ b/tests/test_robot_locator.py
@@ -1,0 +1,159 @@
+import numpy as np
+import pytest
+import rosys
+from rosys.testing import forward
+
+
+async def test_covariance_stays_positive_semidefinite(devkit_system):
+    """Regression test for #348 (cholesky: matrix not positive definite) and
+    #372 (invalid value in matmul).
+
+    Both stem from the naive covariance update ``P = (I - K H) P``: while driving
+    forward, ``F`` couples position and heading, so ``P`` gains off-diagonal terms
+    and the naive update lets it drift into an asymmetric, non-positive-definite
+    matrix (even negative variances). That makes ``cholesky(S)`` fail and, once the
+    resulting garbage turns into NaN, propagates into the predict step ``F @ P @ F.T``.
+
+    The covariance must stay symmetric, positive semi-definite and finite throughout.
+    """
+    s = devkit_system
+
+    async def drive_curve():
+        for _ in range(400):
+            await s.driver.wheels.drive(0.3, 0.3)  # forward + turn couples position and heading
+            await rosys.sleep(0.1)
+    s.automator.start(drive_curve())
+    await forward(until=lambda: s.automator.is_running)
+
+    for _ in range(200):
+        await forward(0.2)
+        covariance = s.robot_locator._Sxx  # noqa: SLF001
+        assert np.all(np.isfinite(covariance)), f'covariance must stay finite:\n{covariance}'
+        eigenvalues = np.linalg.eigvalsh((covariance + covariance.T) / 2)
+        scale = max(float(eigenvalues.max()), 1e-30)
+        assert eigenvalues.min() >= -1e-9 * scale, \
+            f'covariance must stay positive semi-definite, got eigenvalues {eigenvalues}:\n{covariance}'
+        asymmetry = float(np.max(np.abs(covariance - covariance.T)))
+        assert asymmetry <= 1e-9 * scale, f'covariance must stay symmetric (asymmetry {asymmetry:.2e}):\n{covariance}'
+
+
+async def test_covariance_stays_finite_while_driving(devkit_system):
+    """Regression test for #372: the predict step ``F @ P @ F.T`` must never see NaN/Inf."""
+    s = devkit_system
+
+    async def drive_curve():
+        for _ in range(400):
+            await s.driver.wheels.drive(0.3, 0.3)
+            await rosys.sleep(0.1)
+    s.automator.start(drive_curve())
+    await forward(until=lambda: s.automator.is_running)
+    for _ in range(200):
+        await forward(0.2)
+        assert np.all(np.isfinite(s.robot_locator._Sxx)), 'covariance turned non-finite'  # noqa: SLF001
+        assert np.all(np.isfinite(s.robot_locator._x)), 'state turned non-finite'  # noqa: SLF001
+
+
+async def test_dead_reckoning_integrates_odometry(devkit_system):
+    """Without GNSS the prediction step alone must move the pose along the driven odometry."""
+    s = devkit_system
+    s.robot_locator._ignore_gnss = True  # noqa: SLF001
+    await s.driver.wheels.drive(0.2, 0.0)
+    await forward(5.0)
+    await s.driver.wheels.drive(0.0, 0.0)
+    await forward(0.5)
+    assert s.robot_locator.pose.x == pytest.approx(s.feldfreund.wheels.pose.x, abs=0.02)
+    assert s.robot_locator.pose.y == pytest.approx(0.0, abs=0.02)
+    assert s.robot_locator.pose.x > 0.5  # actually moved
+
+
+async def test_standstill_freezes_state(devkit_system):
+    """At standstill the prediction step is skipped, so pose and covariance must not drift."""
+    s = devkit_system
+    s.robot_locator._ignore_gnss = True  # noqa: SLF001
+    await s.driver.wheels.drive(0.2, 0.0)
+    await forward(1.0)
+    await s.driver.wheels.drive(0.0, 0.0)
+    await forward(0.5)
+    pose_before = s.robot_locator.pose
+    covariance_before = s.robot_locator._Sxx.copy()  # noqa: SLF001
+    await forward(3.0)
+    assert s.robot_locator.pose.x == pytest.approx(pose_before.x, abs=1e-9)
+    assert s.robot_locator.pose.y == pytest.approx(pose_before.y, abs=1e-9)
+    assert s.robot_locator.pose.yaw == pytest.approx(pose_before.yaw, abs=1e-9)
+    np.testing.assert_array_equal(s.robot_locator._Sxx, covariance_before)  # noqa: SLF001
+
+
+async def test_uncertainty_grows_during_dead_reckoning(devkit_system):
+    """Driving without GNSS corrections must increase the pose uncertainty."""
+    s = devkit_system
+    s.robot_locator._ignore_gnss = True  # noqa: SLF001
+    await s.driver.wheels.drive(0.2, 0.0)
+    await forward(0.5)
+    uncertainty_before = sum(s.robot_locator.uncertainty)
+    await forward(5.0)
+    uncertainty_after = sum(s.robot_locator.uncertainty)
+    assert uncertainty_after > uncertainty_before
+
+
+async def test_gnss_corrects_injected_error(devkit_system):
+    """A GNSS update must pull an injected pose error back towards the measurement.
+
+    The robot has to be moving: at standstill the prediction step is skipped, the
+    covariance keeps shrinking and the filter becomes overconfident, so it would no
+    longer correct. Driving keeps the process noise (and thus the Kalman gain) alive.
+    """
+    s = devkit_system
+    await forward(2.0)  # let the filter settle at the origin
+    s.robot_locator._x[1, 0] = 1.0  # noqa: SLF001  inject a 1 m error in y
+    s.robot_locator._update_frame()  # noqa: SLF001
+    assert s.robot_locator.pose.y == pytest.approx(1.0, abs=1e-6)
+    await s.driver.wheels.drive(0.2, 0.0)
+    await forward(5.0)
+    await s.driver.wheels.drive(0.0, 0.0)
+    assert s.robot_locator.pose.y == pytest.approx(0.0, abs=0.05)
+
+
+async def test_non_finite_heading_disables_update(devkit_system):
+    """If the GNSS heading uncertainty is not finite, the update is skipped entirely
+    (the Feldfreund relies on RTK heading), so an injected error must NOT be corrected
+    even while driving (which otherwise keeps the Kalman gain alive)."""
+    s = devkit_system
+    await forward(2.0)
+    s.feldfreund.gnss._heading_std_dev = np.inf  # noqa: SLF001
+    await forward(1.0)  # flush a measurement so the guard is exercised
+    s.robot_locator._x[1, 0] = 1.0  # noqa: SLF001
+    s.robot_locator._update_frame()  # noqa: SLF001
+    await s.driver.wheels.drive(0.2, 0.0)
+    await forward(5.0)
+    await s.driver.wheels.drive(0.0, 0.0)
+    assert s.robot_locator.pose.y == pytest.approx(1.0, abs=1e-6)  # uncorrected (straight drive keeps y in odometry)
+
+
+async def test_reset_snaps_pose_to_gnss(devkit_system):
+    """Resetting must discard the current state and adopt the GNSS measurement.
+
+    ``reset`` awaits a *new* GNSS measurement, which only arrives while simulated time
+    advances, so it is run as a background task alongside ``forward``.
+    """
+    s = devkit_system
+    s.robot_locator._x[:, 0] = [5.0, 5.0, 1.0]  # noqa: SLF001  corrupt the state
+    s.robot_locator._update_frame()  # noqa: SLF001
+    rosys.background_tasks.create(s.robot_locator.reset(), name='reset_locator')
+    await forward(3.0)
+    assert s.robot_locator.pose.x == pytest.approx(s.feldfreund.wheels.pose.x, abs=0.05)
+    assert s.robot_locator.pose.y == pytest.approx(s.feldfreund.wheels.pose.y, abs=0.05)
+
+
+def test_combine_odom_imu_slip_reduces_speed(devkit_system):
+    """When odometry and IMU disagree on the angular velocity (wheel slip), the
+    fused linear velocity must be reduced and the angular velocity blended."""
+    locator = devkit_system.robot_locator
+    weight = locator._odometry_angular_weight  # noqa: SLF001
+    # agreement: speed unchanged, angular velocity unchanged
+    v, omega = locator._combine_odom_imu(0.5, 0.2, 0.2)  # noqa: SLF001
+    assert v == pytest.approx(0.5)
+    assert omega == pytest.approx(0.2)
+    # disagreement: linear speed reduced, angular velocity blended towards the IMU
+    v, omega = locator._combine_odom_imu(0.5, 0.2, 1.2)  # noqa: SLF001
+    assert v < 0.5
+    assert omega == pytest.approx(weight * 0.2 + (1 - weight) * 1.2)

--- a/tests/test_robot_locator.py
+++ b/tests/test_robot_locator.py
@@ -27,7 +27,7 @@ async def test_covariance_stays_positive_semidefinite(devkit_system):
 
     for _ in range(200):
         await forward(0.2)
-        covariance = s.robot_locator._Sxx  # noqa: SLF001
+        covariance = s.robot_locator._Sxx
         assert np.all(np.isfinite(covariance)), f'covariance must stay finite:\n{covariance}'
         eigenvalues = np.linalg.eigvalsh((covariance + covariance.T) / 2)
         scale = max(float(eigenvalues.max()), 1e-30)
@@ -49,14 +49,14 @@ async def test_covariance_stays_finite_while_driving(devkit_system):
     await forward(until=lambda: s.automator.is_running)
     for _ in range(200):
         await forward(0.2)
-        assert np.all(np.isfinite(s.robot_locator._Sxx)), 'covariance turned non-finite'  # noqa: SLF001
-        assert np.all(np.isfinite(s.robot_locator._x)), 'state turned non-finite'  # noqa: SLF001
+        assert np.all(np.isfinite(s.robot_locator._Sxx)), 'covariance turned non-finite'
+        assert np.all(np.isfinite(s.robot_locator._x)), 'state turned non-finite'
 
 
 async def test_dead_reckoning_integrates_odometry(devkit_system):
     """Without GNSS the prediction step alone must move the pose along the driven odometry."""
     s = devkit_system
-    s.robot_locator._ignore_gnss = True  # noqa: SLF001
+    s.robot_locator._ignore_gnss = True
     await s.driver.wheels.drive(0.2, 0.0)
     await forward(5.0)
     await s.driver.wheels.drive(0.0, 0.0)
@@ -69,24 +69,24 @@ async def test_dead_reckoning_integrates_odometry(devkit_system):
 async def test_standstill_freezes_state(devkit_system):
     """At standstill the prediction step is skipped, so pose and covariance must not drift."""
     s = devkit_system
-    s.robot_locator._ignore_gnss = True  # noqa: SLF001
+    s.robot_locator._ignore_gnss = True
     await s.driver.wheels.drive(0.2, 0.0)
     await forward(1.0)
     await s.driver.wheels.drive(0.0, 0.0)
     await forward(0.5)
     pose_before = s.robot_locator.pose
-    covariance_before = s.robot_locator._Sxx.copy()  # noqa: SLF001
+    covariance_before = s.robot_locator._Sxx.copy()
     await forward(3.0)
     assert s.robot_locator.pose.x == pytest.approx(pose_before.x, abs=1e-9)
     assert s.robot_locator.pose.y == pytest.approx(pose_before.y, abs=1e-9)
     assert s.robot_locator.pose.yaw == pytest.approx(pose_before.yaw, abs=1e-9)
-    np.testing.assert_array_equal(s.robot_locator._Sxx, covariance_before)  # noqa: SLF001
+    np.testing.assert_array_equal(s.robot_locator._Sxx, covariance_before)
 
 
 async def test_uncertainty_grows_during_dead_reckoning(devkit_system):
     """Driving without GNSS corrections must increase the pose uncertainty."""
     s = devkit_system
-    s.robot_locator._ignore_gnss = True  # noqa: SLF001
+    s.robot_locator._ignore_gnss = True
     await s.driver.wheels.drive(0.2, 0.0)
     await forward(0.5)
     uncertainty_before = sum(s.robot_locator.uncertainty)
@@ -104,8 +104,8 @@ async def test_gnss_corrects_injected_error(devkit_system):
     """
     s = devkit_system
     await forward(2.0)  # let the filter settle at the origin
-    s.robot_locator._x[1, 0] = 1.0  # noqa: SLF001  inject a 1 m error in y
-    s.robot_locator._update_frame()  # noqa: SLF001
+    s.robot_locator._x[1, 0] = 1.0  # inject a 1 m error in y
+    s.robot_locator._update_frame()
     assert s.robot_locator.pose.y == pytest.approx(1.0, abs=1e-6)
     await s.driver.wheels.drive(0.2, 0.0)
     await forward(5.0)
@@ -119,10 +119,10 @@ async def test_non_finite_heading_disables_update(devkit_system):
     even while driving (which otherwise keeps the Kalman gain alive)."""
     s = devkit_system
     await forward(2.0)
-    s.feldfreund.gnss._heading_std_dev = np.inf  # noqa: SLF001
+    s.feldfreund.gnss._heading_std_dev = np.inf
     await forward(1.0)  # flush a measurement so the guard is exercised
-    s.robot_locator._x[1, 0] = 1.0  # noqa: SLF001
-    s.robot_locator._update_frame()  # noqa: SLF001
+    s.robot_locator._x[1, 0] = 1.0
+    s.robot_locator._update_frame()
     await s.driver.wheels.drive(0.2, 0.0)
     await forward(5.0)
     await s.driver.wheels.drive(0.0, 0.0)
@@ -136,8 +136,8 @@ async def test_reset_snaps_pose_to_gnss(devkit_system):
     advances, so it is run as a background task alongside ``forward``.
     """
     s = devkit_system
-    s.robot_locator._x[:, 0] = [5.0, 5.0, 1.0]  # noqa: SLF001  corrupt the state
-    s.robot_locator._update_frame()  # noqa: SLF001
+    s.robot_locator._x[:, 0] = [5.0, 5.0, 1.0]  # corrupt the state
+    s.robot_locator._update_frame()
     rosys.background_tasks.create(s.robot_locator.reset(), name='reset_locator')
     await forward(3.0)
     assert s.robot_locator.pose.x == pytest.approx(s.feldfreund.wheels.pose.x, abs=0.05)
@@ -148,12 +148,12 @@ def test_combine_odom_imu_slip_reduces_speed(devkit_system):
     """When odometry and IMU disagree on the angular velocity (wheel slip), the
     fused linear velocity must be reduced and the angular velocity blended."""
     locator = devkit_system.robot_locator
-    weight = locator._odometry_angular_weight  # noqa: SLF001
+    weight = locator._odometry_angular_weight
     # agreement: speed unchanged, angular velocity unchanged
-    v, omega = locator._combine_odom_imu(0.5, 0.2, 0.2)  # noqa: SLF001
+    v, omega = locator._combine_odom_imu(0.5, 0.2, 0.2)
     assert v == pytest.approx(0.5)
     assert omega == pytest.approx(0.2)
     # disagreement: linear speed reduced, angular velocity blended towards the IMU
-    v, omega = locator._combine_odom_imu(0.5, 0.2, 1.2)  # noqa: SLF001
+    v, omega = locator._combine_odom_imu(0.5, 0.2, 1.2)
     assert v < 0.5
     assert omega == pytest.approx(weight * 0.2 + (1 - weight) * 1.2)


### PR DESCRIPTION
### Motivation

While driving, the RobotLocator's Kalman covariance drifts into an asymmetric, non-positive-definite matrix (even negative variances). This makes `cholesky(S)` fail and lets NaN propagate into the predict step's `F @ P @ F.T` matmul.

### Implementation

Root cause: the naive covariance update `P = (I - K H) P` is not symmetric in finite precision, so rounding errors accumulate until an eigenvalue turns negative. (Forward motion is what creates the off-diagonal position↔heading correlations the naive form then corrupts; standstill/rotation keep `P` diagonal and safe.)

Replaced it with the **Joseph form** `P = A P Aᵀ + K Q Kᵀ` (`A = I - K H`), which is symmetric and positive semi-definite by construction, followed by an explicit `(P + Pᵀ)/2` to clear residual floating-point asymmetry. The diagonal (the variances) is unaffected; only the redundant off-diagonal copies of each covariance are reconciled.

Added `tests/test_robot_locator.py` covering the covariance invariants (the regression for this bug) plus dead-reckoning, standstill freeze, GNSS correction, the non-finite-heading guard, reset, and the odometry/IMU slip fusion.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] I documented breaking changes and set the 'breaking change' label if needed
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
