### PR TITLE
Implement VelocityProvider with filtered velocity from the pose history

### DIFF
--- a/feldfreund_devkit/robot_locator.py
+++ b/feldfreund_devkit/robot_locator.py
@@ -194,14 +194,20 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
         Differencing the EKF pose (instead of forwarding the raw wheel speed) yields a velocity that
         reflects the IMU blend and GNSS corrections folded into the state. The window spreads a discrete
         GNSS correction jump over several samples rather than emitting it as a single-step spike.
+
+        The walk back stops at the first gap larger than the window (e.g. a standstill, during which no
+        history is recorded), so velocity is never differenced across the gap; it recovers one sample later.
         """
         newest_time, newest_x, _ = self._pose_history[-1]
         target_time = newest_time - self.VELOCITY_SMOOTHING_DURATION
-        earlier_time, earlier_x, _ = self._pose_history[0]
-        for entry_time, entry_x, _ in self._pose_history:
-            if entry_time > target_time:
+        earlier_time, earlier_x = newest_time, newest_x
+        previous_time = newest_time
+        for entry_time, entry_x, _ in reversed(self._pose_history):
+            if previous_time - entry_time > self.VELOCITY_SMOOTHING_DURATION:
+                break  # consecutive gap exceeds the smoothing window — don't difference across it
+            earlier_time, earlier_x, previous_time = entry_time, entry_x, entry_time
+            if entry_time <= target_time:
                 break
-            earlier_time, earlier_x = entry_time, entry_x
         dt = newest_time - earlier_time
         if dt <= 0:
             return Velocity(linear=0.0, angular=0.0, time=time)

--- a/feldfreund_devkit/robot_locator.py
+++ b/feldfreund_devkit/robot_locator.py
@@ -63,6 +63,8 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
 
         self.VELOCITY_MEASURED: Event[list[Velocity]] = Event()
         """Emitted per processed wheel velocity with the filtered velocity (argument: list of ``Velocity``)."""
+        self._velocity = Velocity(linear=0.0, angular=0.0, time=self._pose_timestamp)
+        """Last emitted filtered velocity, kept for the developer UI."""
 
         self._ignore_gnss = gnss is None
         self._ignore_imu = imu is None
@@ -156,7 +158,7 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
 
             if velocity.linear == 0 and velocity.angular == 0 and self._first_prediction_done:
                 # NOTE: The robot is not moving, so we don't need to update the state
-                self.VELOCITY_MEASURED.emit([Velocity(linear=0.0, angular=0.0, time=velocity.time)])
+                self._emit_velocity(Velocity(linear=0.0, angular=0.0, time=velocity.time))
                 continue
 
             v = velocity.linear
@@ -191,7 +193,11 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
             self._Sxx = F @ self._Sxx @ F.T + R
             self._update_frame()
             self._first_prediction_done = True
-            self.VELOCITY_MEASURED.emit([self._estimate_velocity(velocity.time)])
+            self._emit_velocity(self._estimate_velocity(velocity.time))
+
+    def _emit_velocity(self, velocity: Velocity) -> None:
+        self._velocity = velocity
+        self.VELOCITY_MEASURED.emit([velocity])
 
     def _estimate_velocity(self, time: float) -> Velocity:
         """Estimate a smoothed velocity by differencing the filtered pose over a short window.
@@ -382,6 +388,8 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
                 ui.label().bind_text_from(self, '_Sxx', lambda m: f'± {m[1, 1]:.3f}m')
                 ui.label().bind_text_from(self, 'pose', lambda p: f'θ: {p.yaw_deg:.2f}°')
                 ui.label().bind_text_from(self, '_Sxx', lambda m: f'± {np.rad2deg(m[2, 2]):.2f}°')
+                ui.label().bind_text_from(self, '_velocity', lambda v: f'v: {v.linear:.2f}m/s')
+                ui.label().bind_text_from(self, '_velocity', lambda v: f'ω: {np.rad2deg(v.angular):.1f}°/s')
 
             with ui.grid(columns=2).classes('w-full'):
                 ui.checkbox('Ignore GNSS', value=self._ignore_gnss).props('dense color=red').classes('col-span-2') \

--- a/feldfreund_devkit/robot_locator.py
+++ b/feldfreund_devkit/robot_locator.py
@@ -24,6 +24,11 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
     """Seconds of past pose estimates kept for time-based lookups via :meth:`_state_at`."""
     VELOCITY_SMOOTHING_DURATION = 0.2
     """Window over which the filtered pose is differenced into the emitted ``VELOCITY_MEASURED`` velocity."""
+    VELOCITY_GAP_THRESHOLD = 0.5
+    """A gap between consecutive pose estimates above this (e.g. a standstill, during which no history is
+    recorded) is treated as a discontinuity the velocity is not differenced across. Kept separate from
+    ``VELOCITY_SMOOTHING_DURATION`` so tuning the smoothing window can't make a normal sample interval look
+    like a gap; must stay comfortably above the odometry sample interval (else every step reads as a gap)."""
 
     def __init__(self,
                  wheels: Wheels, *,
@@ -195,16 +200,17 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
         reflects the IMU blend and GNSS corrections folded into the state. The window spreads a discrete
         GNSS correction jump over several samples rather than emitting it as a single-step spike.
 
-        The walk back stops at the first gap larger than the window (e.g. a standstill, during which no
-        history is recorded), so velocity is never differenced across the gap; it recovers one sample later.
+        The walk back stops at the first gap larger than ``VELOCITY_GAP_THRESHOLD`` (e.g. a standstill,
+        during which no history is recorded), so velocity is never differenced across the gap; it recovers
+        one sample later.
         """
         newest_time, newest_x, _ = self._pose_history[-1]
         target_time = newest_time - self.VELOCITY_SMOOTHING_DURATION
         earlier_time, earlier_x = newest_time, newest_x
         previous_time = newest_time
         for entry_time, entry_x, _ in reversed(self._pose_history):
-            if previous_time - entry_time > self.VELOCITY_SMOOTHING_DURATION:
-                break  # consecutive gap exceeds the smoothing window — don't difference across it
+            if previous_time - entry_time > self.VELOCITY_GAP_THRESHOLD:
+                break  # consecutive gap exceeds the threshold (e.g. a standstill) — don't difference across it
             earlier_time, earlier_x, previous_time = entry_time, entry_x, entry_time
             if entry_time <= target_time:
                 break

--- a/feldfreund_devkit/robot_locator.py
+++ b/feldfreund_devkit/robot_locator.py
@@ -6,14 +6,14 @@ import numpy as np
 import rosys
 import rosys.helpers
 from nicegui import Event, ui
-from rosys.driving import PoseProvider
+from rosys.driving import PoseProvider, VelocityProvider
 from rosys.geometry import Frame3d, FrameProvider, Pose, Pose3d, Rotation, Velocity
 from rosys.hardware import Gnss, GnssMeasurement, GnssSimulation, Imu, ImuMeasurement, Wheels, WheelsSimulation
 
 from .config import GnssConfiguration
 
 
-class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider):
+class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, VelocityProvider):
     """Extended Kalman filter for robot pose estimation using odometry, GNSS, and IMU."""
 
     R_ODOM_LINEAR = 0.1
@@ -22,6 +22,8 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider):
     ODOMETRY_ANGULAR_WEIGHT = 0.1
     POSE_HISTORY_DURATION = 2.0
     """Seconds of past pose estimates kept for time-based lookups via :meth:`_state_at`."""
+    VELOCITY_SMOOTHING_DURATION = 0.2
+    """Window over which the filtered pose is differenced into the emitted ``VELOCITY_MEASURED`` velocity."""
 
     def __init__(self,
                  wheels: Wheels, *,
@@ -53,6 +55,9 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider):
         self._pose_frame = Pose3d().as_frame('feldfreund.robot_locator')
         self.FRAME_UPDATED: Event[Frame3d] = Event()
         """Emitted when the pose frame has been updated (argument: the new pose frame)."""
+
+        self.VELOCITY_MEASURED: Event[list[Velocity]] = Event()
+        """Emitted per processed wheel velocity with the filtered velocity (argument: list of ``Velocity``)."""
 
         self._ignore_gnss = gnss is None
         self._ignore_imu = imu is None
@@ -146,6 +151,7 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider):
 
             if velocity.linear == 0 and velocity.angular == 0 and self._first_prediction_done:
                 # NOTE: The robot is not moving, so we don't need to update the state
+                self.VELOCITY_MEASURED.emit([Velocity(linear=0.0, angular=0.0, time=velocity.time)])
                 continue
 
             v = velocity.linear
@@ -180,6 +186,32 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider):
             self._Sxx = F @ self._Sxx @ F.T + R
             self._update_frame()
             self._first_prediction_done = True
+            self.VELOCITY_MEASURED.emit([self._estimate_velocity(velocity.time)])
+
+    def _estimate_velocity(self, time: float) -> Velocity:
+        """Estimate a smoothed velocity by differencing the filtered pose over a short window.
+
+        Differencing the EKF pose (instead of forwarding the raw wheel speed) yields a velocity that
+        reflects the IMU blend and GNSS corrections folded into the state. The window spreads a discrete
+        GNSS correction jump over several samples rather than emitting it as a single-step spike.
+        """
+        newest_time, newest_x, _ = self._pose_history[-1]
+        target_time = newest_time - self.VELOCITY_SMOOTHING_DURATION
+        earlier_time, earlier_x, _ = self._pose_history[0]
+        for entry_time, entry_x, _ in self._pose_history:
+            if entry_time > target_time:
+                break
+            earlier_time, earlier_x = entry_time, entry_x
+        dt = newest_time - earlier_time
+        if dt <= 0:
+            return Velocity(linear=0.0, angular=0.0, time=time)
+        dx = newest_x[0, 0] - earlier_x[0, 0]
+        dy = newest_x[1, 0] - earlier_x[1, 0]
+        dyaw = rosys.helpers.angle(earlier_x[2, 0], newest_x[2, 0])
+        direction = earlier_x[2, 0] + dyaw / 2  # average heading over the window for the forward projection
+        linear = (dx * np.cos(direction) + dy * np.sin(direction)) / dt
+        angular = dyaw / dt
+        return Velocity(linear=linear, angular=angular, time=time)
 
     def _get_imu_angular_velocity(self) -> float | None:
         if self._previous_imu_measurement is None or self._imu is None or self._imu.last_measurement is None:

--- a/feldfreund_devkit/robot_locator.py
+++ b/feldfreund_devkit/robot_locator.py
@@ -193,13 +193,13 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
             self._Sxx = F @ self._Sxx @ F.T + R
             self._update_frame()
             self._first_prediction_done = True
-            self._emit_velocity(self._estimate_velocity(velocity.time))
+            self._emit_velocity(self._estimate_velocity())
 
     def _emit_velocity(self, velocity: Velocity) -> None:
         self._velocity = velocity
         self.VELOCITY_MEASURED.emit([velocity])
 
-    def _estimate_velocity(self, time: float) -> Velocity:
+    def _estimate_velocity(self) -> Velocity:
         """Estimate a smoothed velocity by differencing the filtered pose over a short window.
 
         Differencing the EKF pose (instead of forwarding the raw wheel speed) yields a velocity that
@@ -207,8 +207,9 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
         GNSS correction jump over several samples rather than emitting it as a single-step spike.
 
         The walk back stops at the first gap larger than ``VELOCITY_GAP_THRESHOLD`` (e.g. a standstill,
-        during which no history is recorded), so velocity is never differenced across the gap; it recovers
-        one sample later.
+        during which no history is recorded), so velocity is never differenced across the gap; otherwise
+        the window would straddle the standstill and under-report the resumed speed. It returns zero for
+        one sample, then recovers.
         """
         newest_time, newest_x, _ = self._pose_history[-1]
         target_time = newest_time - self.VELOCITY_SMOOTHING_DURATION
@@ -222,14 +223,14 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
                 break
         dt = newest_time - earlier_time
         if dt <= 0:
-            return Velocity(linear=0.0, angular=0.0, time=time)
+            return Velocity(linear=0.0, angular=0.0, time=newest_time)
         dx = newest_x[0, 0] - earlier_x[0, 0]
         dy = newest_x[1, 0] - earlier_x[1, 0]
         dyaw = rosys.helpers.angle(earlier_x[2, 0], newest_x[2, 0])
         direction = earlier_x[2, 0] + dyaw / 2  # average heading over the window for the forward projection
         linear = (dx * np.cos(direction) + dy * np.sin(direction)) / dt
         angular = dyaw / dt
-        return Velocity(linear=linear, angular=angular, time=time)
+        return Velocity(linear=linear, angular=angular, time=newest_time)
 
     def _get_imu_angular_velocity(self) -> float | None:
         if self._previous_imu_measurement is None or self._imu is None or self._imu.last_measurement is None:

--- a/tests/test_robot_locator.py
+++ b/tests/test_robot_locator.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 import rosys
+from rosys.geometry import Velocity
 from rosys.testing import forward
 
 
@@ -288,6 +289,45 @@ async def test_gnss_latency_compensation_removes_along_track_lag(devkit_system):
     # without compensation the estimate would trail by ~v*latency = 0.3 * 0.3 = 0.09 m
     assert s.robot_locator.pose.x == pytest.approx(true_x, abs=0.03)
     assert s.robot_locator.pose.y == pytest.approx(0.0, abs=0.03)
+
+
+async def test_velocity_measured_reports_forward_speed(devkit_system):
+    """Driving straight, the emitted filtered velocity must match the driven speed."""
+    s = devkit_system
+    s.robot_locator._ignore_gnss = True
+    measured: list[Velocity] = []
+    s.robot_locator.VELOCITY_MEASURED.subscribe(measured.extend)
+    await s.driver.wheels.drive(0.2, 0.0)
+    await forward(2.0)
+    assert measured[-1].linear == pytest.approx(0.2, abs=0.02)
+    assert measured[-1].angular == pytest.approx(0.0, abs=0.02)
+
+
+async def test_velocity_measured_reports_turn_rate(devkit_system):
+    """Turning in place, the emitted velocity must report the angular rate and ~zero linear speed."""
+    s = devkit_system
+    s.robot_locator._ignore_gnss = True
+    measured: list[Velocity] = []
+    s.robot_locator.VELOCITY_MEASURED.subscribe(measured.extend)
+    await s.driver.wheels.drive(0.0, 0.3)
+    await forward(2.0)
+    assert measured[-1].angular == pytest.approx(0.3, abs=0.03)
+    assert measured[-1].linear == pytest.approx(0.0, abs=0.02)
+
+
+async def test_velocity_measured_is_zero_at_standstill(devkit_system):
+    """At standstill the provider must keep emitting, reporting zero velocity."""
+    s = devkit_system
+    s.robot_locator._ignore_gnss = True
+    await s.driver.wheels.drive(0.2, 0.0)
+    await forward(1.0)
+    await s.driver.wheels.drive(0.0, 0.0)
+    await forward(0.5)  # flush the stop through the filter
+    measured: list[Velocity] = []
+    s.robot_locator.VELOCITY_MEASURED.subscribe(measured.extend)
+    await forward(1.0)
+    assert measured  # still emitting while standing still
+    assert all(v.linear == 0.0 and v.angular == 0.0 for v in measured)
 
 
 def test_combine_odom_imu_slip_reduces_speed(devkit_system):

--- a/tests/test_robot_locator.py
+++ b/tests/test_robot_locator.py
@@ -355,7 +355,7 @@ async def test_velocity_measured_is_zero_at_standstill(devkit_system):
 
 
 async def test_velocity_measured_recovers_after_standstill(devkit_system):
-    """Resuming after a standstill must not difference across the gap (no spike), and recover the speed."""
+    """Resuming after a standstill must not difference across the gap, and recover to the driven speed."""
     s = devkit_system
     s.robot_locator._ignore_gnss = True
     await s.driver.wheels.drive(0.2, 0.0)
@@ -366,8 +366,10 @@ async def test_velocity_measured_recovers_after_standstill(devkit_system):
     s.robot_locator.VELOCITY_MEASURED.subscribe(measured.extend)
     await s.driver.wheels.drive(0.2, 0.0)
     await forward(1.0)
-    assert max(v.linear for v in measured) < 0.3  # no spike from differencing across the gap (forward only)
-    assert measured[-1].linear == pytest.approx(0.2, abs=0.02)  # recovered to the driven speed
+    assert max(v.linear for v in measured) < 0.3  # no overshoot from differencing across the gap
+    # The gap guard keeps the window from straddling the standstill, which would otherwise under-report
+    # the resumed speed for ~VELOCITY_SMOOTHING_DURATION; once the window has refilled the speed is steady.
+    assert all(v.linear == pytest.approx(0.2, abs=0.03) for v in measured[-5:])
 
 
 def test_combine_odom_imu_slip_reduces_speed(devkit_system):

--- a/tests/test_robot_locator.py
+++ b/tests/test_robot_locator.py
@@ -303,8 +303,20 @@ async def test_velocity_measured_reports_forward_speed(devkit_system):
     assert measured[-1].angular == pytest.approx(0.0, abs=0.02)
 
 
+async def test_velocity_measured_reports_reverse_speed(devkit_system):
+    """Driving in reverse, the projected linear velocity must come out negative."""
+    s = devkit_system
+    s.robot_locator._ignore_gnss = True
+    measured: list[Velocity] = []
+    s.robot_locator.VELOCITY_MEASURED.subscribe(measured.extend)
+    await s.driver.wheels.drive(-0.2, 0.0)
+    await forward(2.0)
+    assert measured[-1].linear == pytest.approx(-0.2, abs=0.02)
+    assert measured[-1].angular == pytest.approx(0.0, abs=0.02)
+
+
 async def test_velocity_measured_reports_turn_rate(devkit_system):
-    """Turning in place, the emitted velocity must report the angular rate and ~zero linear speed."""
+    """Turning in place, the emitted velocity must report the (signed) angular rate and ~zero linear speed."""
     s = devkit_system
     s.robot_locator._ignore_gnss = True
     measured: list[Velocity] = []
@@ -312,6 +324,18 @@ async def test_velocity_measured_reports_turn_rate(devkit_system):
     await s.driver.wheels.drive(0.0, 0.3)
     await forward(2.0)
     assert measured[-1].angular == pytest.approx(0.3, abs=0.03)
+    assert measured[-1].linear == pytest.approx(0.0, abs=0.02)
+
+
+async def test_velocity_measured_reports_negative_turn_rate(devkit_system):
+    """A clockwise turn must yield a negative angular velocity (yaw-wrap sign correctness)."""
+    s = devkit_system
+    s.robot_locator._ignore_gnss = True
+    measured: list[Velocity] = []
+    s.robot_locator.VELOCITY_MEASURED.subscribe(measured.extend)
+    await s.driver.wheels.drive(0.0, -0.3)
+    await forward(2.0)
+    assert measured[-1].angular == pytest.approx(-0.3, abs=0.03)
     assert measured[-1].linear == pytest.approx(0.0, abs=0.02)
 
 
@@ -328,6 +352,22 @@ async def test_velocity_measured_is_zero_at_standstill(devkit_system):
     await forward(1.0)
     assert measured  # still emitting while standing still
     assert all(v.linear == 0.0 and v.angular == 0.0 for v in measured)
+
+
+async def test_velocity_measured_recovers_after_standstill(devkit_system):
+    """Resuming after a standstill must not difference across the gap (no spike), and recover the speed."""
+    s = devkit_system
+    s.robot_locator._ignore_gnss = True
+    await s.driver.wheels.drive(0.2, 0.0)
+    await forward(1.0)
+    await s.driver.wheels.drive(0.0, 0.0)
+    await forward(1.0)  # standstill gap longer than the smoothing window
+    measured: list[Velocity] = []
+    s.robot_locator.VELOCITY_MEASURED.subscribe(measured.extend)
+    await s.driver.wheels.drive(0.2, 0.0)
+    await forward(1.0)
+    assert max(v.linear for v in measured) < 0.3  # no spike from differencing across the gap (forward only)
+    assert measured[-1].linear == pytest.approx(0.2, abs=0.02)  # recovered to the driven speed
 
 
 def test_combine_odom_imu_slip_reduces_speed(devkit_system):


### PR DESCRIPTION
### Motivation

`RobotLocator` forwarded only the raw wheel speed, so its filtered estimate wasn't consumable as a `VelocityProvider`. Roadmap item D1; stacked on A1 (#48).

### Implementation

Make `RobotLocator` fulfill the RoSys `VelocityProvider` protocol. Per processed wheel sample, emit `VELOCITY_MEASURED` with a velocity differenced from the EKF pose over a short window (`VELOCITY_SMOOTHING_DURATION`), so it reflects the IMU blend and GNSS corrections and spreads discrete GNSS jumps across the window. The backward walk stops at the first gap larger than `VELOCITY_GAP_THRESHOLD` (e.g. a standstill), so velocity isn't differenced across the gap. Standstill emits zero. No state extension; the last velocity is kept for the developer UI.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] I documented breaking changes and set the 'breaking change' label if needed
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
