### PR TITLE
Support multiple main cameras

### DIFF
--- a/feldfreund_devkit/camera_provider.py
+++ b/feldfreund_devkit/camera_provider.py
@@ -65,12 +65,12 @@ class CameraProvider:
         """
         self.log = logging.getLogger('feldfreund.camera_provider')
         self._config = config
-        self.main = self._setup('main')
+        self.mains: list[rosys.vision.CalibratableCamera] = self._setup_mains()
         self.front = self._setup('front')
         self.back = self._setup('back')
         self.left = self._setup('left')
         self.right = self._setup('right')
-        self._cameras = {cam.id: cam for cam in (self.main, self.front, self.back, self.left, self.right)
+        self._cameras = {cam.id: cam for cam in (*self.mains, self.front, self.back, self.left, self.right)
                          if cam is not None}
 
         if frame_provider is not None:
@@ -81,12 +81,16 @@ class CameraProvider:
             rosys.on_shutdown(self.shutdown)
 
     def slot_config(self, name: CameraPosition) -> CameraSlotConfig | None:
-        """Get the CameraSlotConfig for a given position."""
+        """Get the CameraSlotConfig for a given position.
+
+        For ``'main'``, returns the first configured main; use ``main_slot_configs`` for the full list.
+        """
         if self._config is None:
             return None
         match name:
             case 'main':
-                return self._config.main
+                configs = self.main_slot_configs
+                return configs[0] if configs else None
             case 'front':
                 return self._config.front
             case 'back':
@@ -96,6 +100,18 @@ class CameraProvider:
             case 'right':
                 return self._config.right
         return None
+
+    @property
+    def main_slot_configs(self) -> list[CameraSlotConfig]:
+        """Normalized list of main camera slot configurations (empty when none configured)."""
+        if self._config is None or self._config.main is None:
+            return []
+        return list(self._config.main) if isinstance(self._config.main, list) else [self._config.main]
+
+    @property
+    def main(self) -> rosys.vision.CalibratableCamera | None:
+        """Primary main camera — the first of ``self.mains`` (used where a single camera is needed)."""
+        return self.mains[0] if self.mains else None
 
     @property
     def cameras(self) -> dict[str, rosys.vision.CalibratableCamera]:
@@ -120,6 +136,12 @@ class CameraProvider:
         slot_config = self.slot_config(name)
         if not slot_config:
             return None
+        return self._build_camera(slot_config)
+
+    def _setup_mains(self) -> list[rosys.vision.CalibratableCamera]:
+        return [self._build_camera(c) for c in self.main_slot_configs]
+
+    def _build_camera(self, slot_config: CameraSlotConfig) -> rosys.vision.CalibratableCamera:
         camera = self._create_camera(slot_config)
         if slot_config.calibration is not None:
             camera.calibration = slot_config.calibration
@@ -192,9 +214,20 @@ class CameraProvider:
         self.log.info('Camera scan complete')
 
     def developer_ui(self) -> None:
-        slots: list[tuple[CameraPosition, CalibratableCamera | None]] = [('main', self.main),
-                                                                         ('front', self.front), ('back', self.back),
-                                                                         ('left', self.left), ('right', self.right)]
+        main_configs = self.main_slot_configs
+        slots: list[tuple[str, CalibratableCamera | None, CameraSlotConfig | None]] = []
+        if main_configs:
+            for i, (cam, cfg) in enumerate(zip(self.mains, main_configs, strict=True)):
+                label = 'main' if len(main_configs) == 1 else f'main[{i}]'
+                slots.append((label, cam, cfg))
+        else:
+            slots.append(('main', None, None))
+        slots.extend([
+            ('front', self.front, self.slot_config('front')),
+            ('back', self.back, self.slot_config('back')),
+            ('left', self.left, self.slot_config('left')),
+            ('right', self.right, self.slot_config('right')),
+        ])
         with ui.column():
             ui.label('Cameras').classes('text-center text-bold')
             with ui.grid(columns='auto auto auto auto').classes('items-center'):
@@ -202,7 +235,7 @@ class CameraProvider:
                 ui.label('Connected').classes('font-bold')
                 ui.label('Resolution').classes('font-bold')
                 ui.label('Type').classes('font-bold')
-                for name, camera in slots:
+                for name, camera, slot_cfg in slots:
                     ui.label(name)
                     if camera is None:
                         status_bulb()
@@ -219,5 +252,5 @@ class CameraProvider:
                             label.set_text(f'{image.size.width}x{image.size.height}' if image else '—')
 
                         ui.timer(5.0, update_resolution)
-                        ui.label(self._camera_config_name(self.slot_config(name)))
+                        ui.label(self._camera_config_name(slot_cfg))
             ui.button('Scan for cameras', on_click=self.scan)

--- a/feldfreund_devkit/camera_provider.py
+++ b/feldfreund_devkit/camera_provider.py
@@ -70,8 +70,12 @@ class CameraProvider:
         self.back = self._setup('back')
         self.left = self._setup('left')
         self.right = self._setup('right')
-        self._cameras = {cam.id: cam for cam in (*self.mains, self.front, self.back, self.left, self.right)
-                         if cam is not None}
+        cameras = [cam for cam in (*self.mains, self.front, self.back, self.left, self.right) if cam is not None]
+        ids = [cam.id for cam in cameras]
+        duplicate_ids = sorted({cam_id for cam_id in ids if ids.count(cam_id) > 1})
+        if duplicate_ids:
+            raise ValueError(f'Duplicate camera id(s) in configuration: {", ".join(duplicate_ids)}')
+        self._cameras = {cam.id: cam for cam in cameras}
 
         if frame_provider is not None:
             self.set_frame_provider(frame_provider)

--- a/feldfreund_devkit/config/camera_configuration.py
+++ b/feldfreund_devkit/config/camera_configuration.py
@@ -140,8 +140,9 @@ class MjpegCameraConfig(CameraSlotConfig):
 class CameraConfiguration:
     """Container of named camera slots for a Feldfreund robot.
 
-    ``main`` may be a single ``CameraSlotConfig`` or a list of them; the list form lets the
-    stereo locator triangulate across physically separated main cameras within a single stop.
+    ``main`` may be a single ``CameraSlotConfig`` or a list of them. The list form configures
+    multiple main cameras; ``CameraProvider.main`` then refers to the first, while
+    ``CameraProvider.mains`` exposes all of them.
 
     Defaults:
         left: None

--- a/feldfreund_devkit/config/camera_configuration.py
+++ b/feldfreund_devkit/config/camera_configuration.py
@@ -140,11 +140,14 @@ class MjpegCameraConfig(CameraSlotConfig):
 class CameraConfiguration:
     """Container of named camera slots for a Feldfreund robot.
 
+    ``main`` may be a single ``CameraSlotConfig`` or a list of them; the list form lets the
+    stereo locator triangulate across physically separated main cameras within a single stop.
+
     Defaults:
         left: None
         right: None
     """
-    main: CameraSlotConfig | None
+    main: CameraSlotConfig | list[CameraSlotConfig] | None
     front: CameraSlotConfig | None
     back: CameraSlotConfig | None
     left: CameraSlotConfig | None = None

--- a/tests/test_camera_provider.py
+++ b/tests/test_camera_provider.py
@@ -69,6 +69,16 @@ async def test_empty_main_list(robot_locator):
     assert provider.cameras == {}
 
 
+async def test_duplicate_camera_ids_raise(robot_locator):
+    config = CameraConfiguration(
+        main=UsbCameraConfig(camera_id='cam-0', image_size=ImageSize(width=1280, height=720)),
+        front=MjpegCameraConfig(camera_id='cam-0', image_size=ImageSize(width=640, height=480), password='test-pw'),
+        back=None,
+    )
+    with pytest.raises(ValueError, match='Duplicate camera id'):
+        CameraProvider(config, frame_provider=robot_locator)
+
+
 async def test_simulation_creates_simulated_cameras(robot_locator):
     config = CameraConfiguration(
         main=UsbCameraConfig(camera_id='usb-0', image_size=ImageSize(width=1280, height=720)),

--- a/tests/test_camera_provider.py
+++ b/tests/test_camera_provider.py
@@ -41,6 +41,34 @@ async def test_slots_assigned(robot_locator):
     assert len(provider.cameras) == 2
 
 
+async def test_multiple_mains(robot_locator):
+    config = CameraConfiguration(
+        main=[
+            UsbCameraConfig(camera_id='usb-0', image_size=ImageSize(width=1280, height=720)),
+            UsbCameraConfig(camera_id='usb-1', image_size=ImageSize(width=1280, height=720)),
+        ],
+        front=None,
+        back=None,
+    )
+    provider = CameraProvider(config, frame_provider=robot_locator)
+    assert len(provider.mains) == 2
+    assert provider.main is provider.mains[0]
+    assert [cam.id for cam in provider.mains] == ['usb-0', 'usb-1']
+    assert len(provider.main_slot_configs) == 2
+    assert len(provider.cameras) == 2
+    assert provider.slot_config('main') is provider.main_slot_configs[0]
+
+
+async def test_empty_main_list(robot_locator):
+    config = CameraConfiguration(main=[], front=None, back=None)
+    provider = CameraProvider(config, frame_provider=robot_locator)
+    assert provider.main is None
+    assert provider.mains == []
+    assert provider.main_slot_configs == []
+    assert provider.slot_config('main') is None
+    assert provider.cameras == {}
+
+
 async def test_simulation_creates_simulated_cameras(robot_locator):
     config = CameraConfiguration(
         main=UsbCameraConfig(camera_id='usb-0', image_size=ImageSize(width=1280, height=720)),

--- a/tests/test_camera_provider.py
+++ b/tests/test_camera_provider.py
@@ -69,10 +69,23 @@ async def test_empty_main_list(robot_locator):
     assert provider.cameras == {}
 
 
-async def test_duplicate_camera_ids_raise(robot_locator):
+async def test_duplicate_camera_ids_across_slots_raise(robot_locator):
     config = CameraConfiguration(
         main=UsbCameraConfig(camera_id='cam-0', image_size=ImageSize(width=1280, height=720)),
         front=MjpegCameraConfig(camera_id='cam-0', image_size=ImageSize(width=640, height=480), password='test-pw'),
+        back=None,
+    )
+    with pytest.raises(ValueError, match='Duplicate camera id'):
+        CameraProvider(config, frame_provider=robot_locator)
+
+
+async def test_duplicate_camera_ids_among_mains_raise(robot_locator):
+    config = CameraConfiguration(
+        main=[
+            UsbCameraConfig(camera_id='cam-0', image_size=ImageSize(width=1280, height=720)),
+            UsbCameraConfig(camera_id='cam-0', image_size=ImageSize(width=1280, height=720)),
+        ],
+        front=None,
         back=None,
     )
     with pytest.raises(ValueError, match='Duplicate camera id'):


### PR DESCRIPTION
### Motivation

Some field friends may have multiple main/internal cameras that we want to get images from.

### Implementation

The camera configuration now supports receiving a list of CameraSlotConfigs. Backwards compatibility is achieved by also allowing a single camera, and providing a computed attribute for the first of the main cams.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] I documented breaking changes and set the 'breaking change' label if needed
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
