### PR TITLE
Pass configured with and height to MjpegCameras

### DIFF
--- a/feldfreund_devkit/config/camera_configuration.py
+++ b/feldfreund_devkit/config/camera_configuration.py
@@ -133,7 +133,7 @@ class MjpegCameraConfig(CameraSlotConfig):
     @property
     def camera_kwargs(self) -> dict:
         return {**super().camera_kwargs, 'username': self.username, 'password': self.password,
-                'ip': self.ip}
+                'ip': self.ip, 'resolution': (self.width, self.height)}
 
 
 @dataclass(kw_only=True)


### PR DESCRIPTION
### Motivation

With the latest [changes to rosys](https://github.com/zauberzeug/rosys/pull/418), we can set the resolution to (more) MjpegCameras. The current code doesn't pass through the actual resolution and thus always sets (640, 480), though.

### Implementation

Pass CameraSlotConfig's `width` and `height` as `resolution` to the MjpegCamera constructor.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] I documented breaking changes and set the 'breaking change' label if needed
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
