### PR TITLE
Add recorded-track navigation

### DIFF
--- a/feldfreund_devkit/interface/components/__init__.py
+++ b/feldfreund_devkit/interface/components/__init__.py
@@ -4,12 +4,24 @@ from .log_monitor import LogMonitor
 from .status_bulb import StatusBulb as status_bulb
 from .teltonika_status_widget import teltonika_status_widget
 from .teltonika_ui import teltonika_ui
+from .track_recorder_dialog import (
+    TRACK_COLOR_DEFAULT,
+    TRACK_COLOR_STOPP_AT_WP,
+    TRACK_COLOR_USE_IMPLEMENT,
+)
+from .track_recorder_dialog import (
+    TrackRecorderDialog as track_recorder_dialog,
+)
 
 __all__ = [
+    'TRACK_COLOR_DEFAULT',
+    'TRACK_COLOR_STOPP_AT_WP',
+    'TRACK_COLOR_USE_IMPLEMENT',
     'LogMonitor',
     'confirm_dialog',
     'header_bar',
     'status_bulb',
     'teltonika_status_widget',
     'teltonika_ui',
+    'track_recorder_dialog',
 ]

--- a/feldfreund_devkit/interface/components/track_recorder_dialog.py
+++ b/feldfreund_devkit/interface/components/track_recorder_dialog.py
@@ -96,6 +96,7 @@ class RecordedTrackList:
             if self.recorded_track.waypoints:
                 for i, wp in enumerate(self.recorded_track.waypoints):
                     self._create_waypoint_row(i, wp)
+            else:
                 with ui.column().classes('w-full items-center text-center gap-2 py-8 text-gray-500'):
                     ui.icon('place', size='lg')
                     ui.label('Drive the robot, then press Add Waypoint (or Space) to record your first point.') \

--- a/feldfreund_devkit/interface/components/track_recorder_dialog.py
+++ b/feldfreund_devkit/interface/components/track_recorder_dialog.py
@@ -1,0 +1,500 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+import rosys
+from nicegui import ui
+from nicegui.elements.leaflet.leaflet_layers import GenericLayer, Marker
+from rosys.driving.driver import PoseProvider
+from rosys.geometry import GeoPose
+from rosys.hardware import Gnss
+
+from ...navigation.recorded_track import (
+    GnssRequirement,
+    RecordedTrack,
+    RecordedTrackProvider,
+    RecordedWaypoint,
+)
+from ...navigation.track_recording_controller import TrackRecordingController
+from .confirm_dialog import ConfirmDialog as confirm_dialog
+
+log = logging.getLogger('feldfreund_devkit.track_recorder')
+
+TRACK_COLOR_DEFAULT = '#6E93D6'
+TRACK_COLOR_USE_IMPLEMENT = '#F2C037'
+TRACK_COLOR_STOPP_AT_WP = '#D6716E'
+
+
+def _marker_style(wp: RecordedWaypoint, *, highlighted: bool = False) -> dict[str, Any]:
+    color = (
+        TRACK_COLOR_STOPP_AT_WP if wp.stop_at_waypoint else
+        TRACK_COLOR_USE_IMPLEMENT if wp.use_implement else
+        TRACK_COLOR_DEFAULT
+    )
+    return {
+        'color': color,
+        'fillColor': color,
+        'fillOpacity': 0.95 if highlighted else 0.8,
+        'radius': 10 if highlighted else 6,
+    }
+
+
+class RecordedTrackList:
+    """Side panel showing the waypoints in the active recording, with row controls."""
+
+    def __init__(
+        self,
+        recorded_track: RecordedTrack,
+        provider: RecordedTrackProvider,
+        on_change: Callable[[], None] | None = None,
+        on_select: Callable[[int], None] | None = None,
+    ) -> None:
+        self.recorded_track = recorded_track
+        self.provider = provider
+        self._on_change = on_change
+        self._on_select = on_select
+        self._rows: list[ui.row] = []
+        self._selected_index: int | None = None
+        self._scroll_percent: float = 1.0
+
+        self.container = ui.column().classes('w-full h-full gap-1')
+        with self.container:
+            self._scroll_area = ui.scroll_area(on_scroll=self._on_scroll).classes('flex-grow w-full')
+            with ui.row().classes('w-full justify-center'):
+                self._waypoint_count_label = ui.label().classes('text-sm text-gray-600')
+        self._render_waypoints()
+
+    def _on_scroll(self, e) -> None:
+        self._scroll_percent = e.vertical_percentage
+
+    def select(self, index: int) -> None:
+        """Select a waypoint from outside (e.g. map click). Scrolls into view."""
+        if not 0 <= index < len(self._rows):
+            return
+        self._selected_index = index
+        for r in self._rows:
+            r.classes(remove='bg-blue-100')
+        self._rows[index].classes(add='bg-blue-100')
+        if len(self._rows) > 1:
+            self._scroll_area.scroll_to(percent=index / max(1, len(self._rows) - 1))
+
+    def notify_waypoints_changed(self) -> None:
+        was_at_bottom = self._scroll_percent > 0.9
+        self._render_waypoints()
+        self._apply_selection()
+        if was_at_bottom or self._selected_index is None:
+            self._scroll_area.scroll_to(percent=1.0)
+        else:
+            self._scroll_area.scroll_to(percent=self._scroll_percent)
+
+    def _render_waypoints(self) -> None:
+        self._rows.clear()
+        self._scroll_area.clear()
+        with self._scroll_area:
+            if self.recorded_track.waypoints:
+                for i, wp in enumerate(self.recorded_track.waypoints):
+                    self._create_waypoint_row(i, wp)
+                with ui.column().classes('w-full items-center text-center gap-2 py-8 text-gray-500'):
+                    ui.icon('place', size='lg')
+                    ui.label('Drive the robot, then press Add Waypoint (or Space) to record your first point.') \
+                        .classes('text-sm')
+        self._waypoint_count_label.set_text(f'{len(self.recorded_track.waypoints)} waypoints')
+
+    def _create_waypoint_row(self, index: int, wp: RecordedWaypoint) -> None:
+        n = len(self.recorded_track.waypoints)
+        row = ui.row().classes(
+            'w-full items-center gap-1 cursor-pointer rounded px-2 py-1 hover:bg-gray-100'
+        )
+        self._rows.append(row)
+        with row:
+            row.on('click', lambda idx=index, r=row: self._select_waypoint(idx, r))
+            ui.label(f'{index + 1}').classes('text-sm font-bold w-6 text-right')
+            with ui.row().classes('flex-grow gap-1 items-center'):
+                self._chip(wp.approach_reverse, 'arrow_back', 'Reverse',
+                           lambda v: self._set_approach_reverse(index, v),
+                           tooltip='Drive backwards to this waypoint')
+                self._chip(wp.use_implement, 'construction', 'Implement',
+                           lambda v: self._set_use_implement(index, v),
+                           tooltip='Allow implement usage on the segment to this waypoint')
+                self._chip(wp.stop_at_waypoint, 'stop_circle', 'Stop',
+                           lambda v: self._set_stop_at_waypoint(index, v),
+                           tooltip='Stop at this waypoint')
+                ui.button(icon='arrow_upward', on_click=lambda idx=index: self._move_up(idx)) \
+                    .props('flat round dense size=sm') \
+                    .tooltip('Move up') \
+                    .set_enabled(index > 0)
+                ui.button(icon='arrow_downward', on_click=lambda idx=index: self._move_down(idx)) \
+                    .props('flat round dense size=sm') \
+                    .tooltip('Move down') \
+                    .set_enabled(index < n - 1)
+                ui.button(icon='delete', on_click=lambda idx=index: self._delete_waypoint(idx)) \
+                    .props('flat round dense color=red size=sm') \
+                    .tooltip('Delete waypoint')
+
+    @staticmethod
+    def _chip(value: bool, icon: str, label: str, on_toggle: Callable[[bool], None], *, tooltip: str) -> None:
+        chip = ui.chip(label, icon=icon, color='primary' if value else 'grey-3',
+                       text_color='white' if value else 'grey-8') \
+            .props('clickable dense')
+        chip.tooltip(tooltip)
+        state = {'value': value}
+
+        def _toggle(_=None) -> None:
+            state['value'] = not state['value']
+            on_toggle(state['value'])
+            chip.props(f'color={"primary" if state["value"] else "grey-3"}')
+            chip.props(f'text-color={"white" if state["value"] else "grey-8"}')
+
+        chip.on('click', _toggle)
+
+    def _move_up(self, index: int) -> None:
+        if index <= 0:
+            return
+        self.recorded_track.move_waypoint(index, index - 1)
+        self.provider.notify_track_modified()
+        if self._selected_index == index:
+            self._selected_index = index - 1
+        elif self._selected_index == index - 1:
+            self._selected_index = index
+        self._notify_change()
+
+    def _move_down(self, index: int) -> None:
+        if index >= len(self.recorded_track.waypoints) - 1:
+            return
+        self.recorded_track.move_waypoint(index, index + 1)
+        self.provider.notify_track_modified()
+        if self._selected_index == index:
+            self._selected_index = index + 1
+        elif self._selected_index == index + 1:
+            self._selected_index = index
+        self._notify_change()
+
+    def _select_waypoint(self, index: int, row: ui.row) -> None:
+        self._selected_index = index
+        for r in self._rows:
+            r.classes(remove='bg-blue-100')
+        row.classes(add='bg-blue-100')
+        if self._on_select:
+            self._on_select(index)
+
+    def _apply_selection(self, *, notify_map: bool = False) -> None:
+        if self._selected_index is not None and 0 <= self._selected_index < len(self._rows):
+            self._rows[self._selected_index].classes(add='bg-blue-100')
+            if notify_map and self._on_select:
+                self._on_select(self._selected_index)
+
+    def _set_approach_reverse(self, index: int, value: bool) -> None:
+        self.recorded_track.set_waypoint_approach_reverse(index, value)
+        self.provider.notify_track_modified()
+        if self._on_change:
+            self._on_change()
+
+    def _set_use_implement(self, index: int, value: bool) -> None:
+        self.recorded_track.set_waypoint_use_implement(index, value)
+        self.provider.notify_track_modified()
+        if self._on_change:
+            self._on_change()
+
+    def _set_stop_at_waypoint(self, index: int, value: bool) -> None:
+        self.recorded_track.set_waypoint_stop_at_waypoint(index, value)
+        self.provider.notify_track_modified()
+        if self._on_change:
+            self._on_change()
+
+    def _delete_waypoint(self, index: int) -> None:
+        self.recorded_track.remove_waypoint(index)
+        self.provider.notify_track_modified()
+        if self._selected_index is not None:
+            if self._selected_index == index:
+                self._selected_index = None
+            elif self._selected_index > index:
+                self._selected_index -= 1
+        self._notify_change()
+
+    def _notify_change(self) -> None:
+        saved_percent = self._scroll_percent
+        self._render_waypoints()
+        if self._on_change:
+            self._on_change()
+        self._apply_selection(notify_map=True)
+        self._scroll_area.scroll_to(percent=saved_percent)
+
+
+class TrackRecorderDialog:
+
+    def __init__(self, existing_track: RecordedTrack, *,
+                 recorded_track_provider: RecordedTrackProvider,
+                 track_recording_controller: TrackRecordingController,
+                 pose_provider: PoseProvider,
+                 gnss: Gnss | None = None) -> None:
+        self.provider = recorded_track_provider
+        self.controller = track_recording_controller
+        self.pose_provider = pose_provider
+        self.gnss = gnss
+
+        self.recorded_track = existing_track
+
+        self.dialog: ui.dialog = None  # type: ignore[assignment]
+        self.dialog_map: ui.leaflet = None  # type: ignore[assignment]
+        self.robot_marker: Marker | None = None
+        self.recorded_track_ui: RecordedTrackList = None  # type: ignore[assignment]
+        self._elapsed_label: ui.label | None = None
+        self._count_label: ui.label = None  # type: ignore[assignment]
+        self._gnss_pill: ui.chip | None = None
+        self._add_button: ui.button | None = None
+        self._undo_button: ui.button | None = None
+        self._recording_action_row: ui.row | None = None
+        self._view_action_row: ui.row | None = None
+
+        self._track_segments: list[GenericLayer] = []
+        self._waypoint_markers: list[GenericLayer] = []
+
+        self._build_dialog()
+        self._update_track_on_map()
+        self._update_status()
+        self._apply_mode()
+        self.dialog.open()
+
+        self.controller.WAYPOINT_ADDED.subscribe(self._on_waypoint_added)
+        self.controller.RECORDING_STARTED.subscribe(self._on_recording_started)
+        self.controller.RECORDING_STOPPED.subscribe(self._on_recording_stopped)
+        self.dialog.on('hide', self._unsubscribe)
+
+    @property
+    def is_recording(self) -> bool:
+        return self.controller.is_recording and self.controller.active_track is self.recorded_track
+
+    @property
+    def current_position(self) -> GeoPose:
+        return GeoPose.from_pose(self.pose_provider.pose)
+
+    def _unsubscribe(self) -> None:
+        self.controller.WAYPOINT_ADDED.unsubscribe(self._on_waypoint_added)
+        self.controller.RECORDING_STARTED.unsubscribe(self._on_recording_started)
+        self.controller.RECORDING_STOPPED.unsubscribe(self._on_recording_stopped)
+
+    def _build_dialog(self) -> None:
+        with ui.dialog() as self.dialog, \
+                ui.card().style('width: 1100px; max-width: 95vw; padding: 12px'):
+            self._build_status_bar()
+            with ui.row().classes('w-full no-wrap gap-3').style('height: 460px'):
+                with ui.column().classes('h-full').style('flex: 0 0 60%'):
+                    self._build_map()
+                with ui.column().classes('h-full').style('flex: 0 0 38%'):
+                    self.recorded_track_ui = RecordedTrackList(
+                        self.recorded_track, self.provider,
+                        on_change=self._update_track_on_map,
+                        on_select=self._highlight_waypoint,
+                    )
+            ui.separator()
+            self._build_action_bar()
+        ui.keyboard(on_key=self._on_key)
+
+    def _build_status_bar(self) -> None:
+        with ui.row().classes('w-full items-center gap-3 px-1'):
+            ui.input(value=self.recorded_track.name) \
+                .on_value_change(lambda e: setattr(self.recorded_track, 'name', e.value)) \
+                .props('dense outlined') \
+                .classes('w-64') \
+                .tooltip('Track name')
+            self._elapsed_label = ui.label('0:00').classes('text-sm font-mono text-gray-600')
+            self._count_label = ui.label('0 waypoints').classes('text-sm text-gray-600')
+            self._gnss_pill = ui.chip('', icon='gps_fixed').props('dense')
+            ui.space()
+            ui.button(icon='close', on_click=self.dialog.close) \
+                .props('flat round dense') \
+                .tooltip('Hide dialog — recording continues. Use the recorded-track settings panel to stop or reopen.')
+
+    def _build_map(self) -> None:
+        self.dialog_map = ui.leaflet(
+            center=self.current_position.point.degree_tuple,
+            zoom=18,
+        ).classes('w-full h-full')
+        self.dialog_map.tile_layer(
+            url_template=r'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+            options={
+                'maxZoom': 24,
+                'maxNativeZoom': 18,
+                'attribution': '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+            },
+        )
+        self.update_robot_position()
+        ui.timer(1, self._tick)
+
+    def _build_action_bar(self) -> None:
+        with ui.row().classes('w-full items-center gap-3 px-1'):
+            ui.select(
+                {GnssRequirement.NONE: 'None', GnssRequirement.GNSS: 'GNSS', GnssRequirement.RTK: 'RTK'},
+                value=self.recorded_track.gnss_requirement,
+                label='Min. GPS',
+                on_change=self._on_gnss_requirement_changed,
+            ).classes('w-32')
+            ui.button(icon='delete', color='red', on_click=self._delete_track) \
+                .tooltip('Delete this track.')
+            self._recording_action_row = ui.row().classes('items-center gap-3 flex-grow')
+            with self._recording_action_row:
+                ui.space()
+                self._undo_button = ui.button('Undo last', icon='undo', on_click=self._undo_last) \
+                    .props('flat') \
+                    .tooltip('Remove the most recently added waypoint')
+                self._add_button = ui.button('Add Waypoint', icon='add_location_alt', on_click=self._add_waypoint)
+                if self.gnss is not None:
+                    self._add_button.bind_enabled_from(
+                        self.gnss, 'last_measurement',
+                        backward=lambda m: self.recorded_track.meets_gnss_requirement(m.gps_quality if m else None),
+                    )
+                ui.button('Finish recording', icon='stop', on_click=self._finish) \
+                    .props('outline color=red')
+            self._view_action_row = ui.row().classes('items-center gap-3 flex-grow')
+            with self._view_action_row:
+                ui.space()
+                ui.button('Start Recording', icon='fiber_manual_record', on_click=self._start_recording)
+
+    def _tick(self) -> None:
+        self.update_robot_position()
+        self._update_status()
+
+    def _update_status(self) -> None:
+        if self._elapsed_label is None:
+            return
+        seconds = int(self.controller.elapsed_seconds)
+        self._elapsed_label.set_text(f'{seconds // 60}:{seconds % 60:02d}')
+        n = len(self.recorded_track.waypoints)
+        self._count_label.set_text(f'{n} waypoint{"s" if n != 1 else ""}')
+        if self._undo_button is not None:
+            self._undo_button.set_enabled(n > 0)
+        self._update_gnss_pill()
+
+    def _update_gnss_pill(self) -> None:
+        if self._gnss_pill is None:
+            return
+        if self.gnss is None:
+            self._gnss_pill.set_text('GNSS not configured')
+            self._gnss_pill.props('color=grey-5 text-color=white')
+            return
+        meets = self._meets_gnss_requirement
+        quality = self.gnss.last_measurement.gps_quality if self.gnss.last_measurement else None
+        label = quality.name if quality is not None else 'NO FIX'
+        self._gnss_pill.set_text(label)
+        self._gnss_pill.props(f'color={"positive" if meets else "negative"} text-color=white')
+
+    def update_robot_position(self) -> None:
+        geo_pose = GeoPose.from_pose(self.pose_provider.pose)
+        latlng = geo_pose.point.degree_tuple
+        self.robot_marker = self.robot_marker or self.dialog_map.marker(latlng=latlng)
+        icon = 'L.icon({iconUrl: "assets/robot_position_side.png", iconSize: [50,50], iconAnchor:[20,20]})'
+        self.robot_marker.run_method(':setIcon', icon)
+        self.robot_marker.move(*latlng)
+
+    def _on_key(self, e) -> None:
+        if not (self.dialog.value and e.action.keydown and not e.action.repeat):
+            return
+        if e.key.name != ' ':
+            return
+        if not self._meets_gnss_requirement:
+            return
+        rosys.background_tasks.create(self._add_waypoint(), name='add waypoint via space')
+
+    @property
+    def _meets_gnss_requirement(self) -> bool:
+        if self.gnss is None:
+            return True
+        measurement = self.gnss.last_measurement
+        gps_quality = measurement.gps_quality if measurement else None
+        return self.recorded_track.meets_gnss_requirement(gps_quality)
+
+    async def _add_waypoint(self) -> None:
+        if not self._meets_gnss_requirement:
+            rosys.notify('GNSS quality insufficient', 'negative')
+            return
+        await self.controller.add_waypoint_at_current_pose()
+
+    def _undo_last(self) -> None:
+        if not self.recorded_track.waypoints:
+            return
+        self.recorded_track.remove_waypoint(len(self.recorded_track.waypoints) - 1)
+        self.provider.notify_track_modified()
+        self.recorded_track_ui.notify_waypoints_changed()
+        self._update_track_on_map()
+        self._update_status()
+
+    def _on_gnss_requirement_changed(self, e) -> None:
+        self.recorded_track.gnss_requirement = e.value
+        self.provider.notify_track_modified()
+
+    def _on_waypoint_added(self) -> None:
+        self._update_track_on_map()
+        self.recorded_track_ui.notify_waypoints_changed()
+        self._update_status()
+
+    def _on_recording_started(self) -> None:
+        self._apply_mode()
+        self._update_status()
+
+    def _on_recording_stopped(self) -> None:
+        self._apply_mode()
+        self._update_status()
+
+    def _apply_mode(self) -> None:
+        if self._recording_action_row is not None:
+            self._recording_action_row.set_visibility(self.is_recording)
+        if self._view_action_row is not None:
+            self._view_action_row.set_visibility(not self.is_recording)
+
+    def _start_recording(self) -> None:
+        if self.is_recording:
+            return
+        rosys.background_tasks.create(
+            self.controller.start_recording(self.recorded_track),
+            name='start track recording from dialog',
+        )
+
+    async def _delete_track(self) -> None:
+        active = self.controller.active_track
+        if active is not None and active.id == self.recorded_track.id:
+            rosys.notify('Cannot delete a track while it is being recorded', 'warning')
+            return
+        if not await confirm_dialog('Are you sure you want to delete this track?'):
+            return
+        self.provider.remove_recorded_track(self.recorded_track.id)
+        self.dialog.close()
+
+    async def _finish(self) -> None:
+        await self.controller.stop_recording()
+
+    def _highlight_waypoint(self, index: int) -> None:
+        for i, marker in enumerate(self._waypoint_markers):
+            wp = self.recorded_track.waypoints[i]
+            marker.run_method('setStyle', _marker_style(wp, highlighted=i == index))
+
+    def _update_track_on_map(self) -> None:
+        for s in self._track_segments:
+            self.dialog_map.remove_layer(s)
+        self._track_segments.clear()
+        for m in self._waypoint_markers:
+            self.dialog_map.remove_layer(m)
+        self._waypoint_markers.clear()
+
+        waypoints = self.recorded_track.waypoints
+        for i in range(1, len(waypoints)):
+            prev_wp = waypoints[i - 1]
+            curr_wp = waypoints[i]
+            color = (TRACK_COLOR_USE_IMPLEMENT if curr_wp.use_implement
+                     else TRACK_COLOR_DEFAULT)
+            options: dict[str, Any] = {'color': color, 'weight': 3}
+            if curr_wp.approach_reverse:
+                options['dashArray'] = '6,6'
+            segment = self.dialog_map.generic_layer(
+                name='polyline',
+                args=[[prev_wp.degree_tuple, curr_wp.degree_tuple], options],
+            )
+            self._track_segments.append(segment)
+
+        for _i, wp in enumerate(waypoints):
+            marker = self.dialog_map.generic_layer(
+                name='circleMarker',
+                args=[list(wp.degree_tuple), _marker_style(wp)],
+            )
+            self._waypoint_markers.append(marker)

--- a/feldfreund_devkit/interface/components/track_recorder_dialog.py
+++ b/feldfreund_devkit/interface/components/track_recorder_dialog.py
@@ -228,11 +228,15 @@ class TrackRecorderDialog:
                  recorded_track_provider: RecordedTrackProvider,
                  track_recording_controller: TrackRecordingController,
                  pose_provider: PoseProvider,
-                 gnss: Gnss | None = None) -> None:
+                 gnss: Gnss | None = None,
+                 robot_marker_icon_url: str | None = None) -> None:
         self.provider = recorded_track_provider
         self.controller = track_recording_controller
         self.pose_provider = pose_provider
         self.gnss = gnss
+        # URL of the robot marker image (served by the app, e.g. 'assets/robot.png').
+        # When None the map shows Leaflet's default marker.
+        self.robot_marker_icon_url = robot_marker_icon_url
 
         self.recorded_track = existing_track
 
@@ -384,8 +388,9 @@ class TrackRecorderDialog:
         geo_pose = GeoPose.from_pose(self.pose_provider.pose)
         latlng = geo_pose.point.degree_tuple
         self.robot_marker = self.robot_marker or self.dialog_map.marker(latlng=latlng)
-        icon = 'L.icon({iconUrl: "assets/robot_position_side.png", iconSize: [50,50], iconAnchor:[20,20]})'
-        self.robot_marker.run_method(':setIcon', icon)
+        if self.robot_marker_icon_url is not None:
+            icon = f'L.icon({{iconUrl: "{self.robot_marker_icon_url}", iconSize: [50,50], iconAnchor: [20,20]}})'
+            self.robot_marker.run_method(':setIcon', icon)
         self.robot_marker.move(*latlng)
 
     def _on_key(self, e) -> None:

--- a/feldfreund_devkit/navigation/__init__.py
+++ b/feldfreund_devkit/navigation/__init__.py
@@ -1,11 +1,20 @@
 from .drive_segment import DriveSegment
+from .recorded_track import GnssRequirement, RecordedTrack, RecordedTrackProvider, RecordedWaypoint
+from .recorded_track_navigation import RecordedTrackNavigation
 from .straight_line_navigation import StraightLineNavigation
+from .track_recording_controller import TrackRecordingController
 from .utils import generate_three_point_turn, is_reference_valid, skip_completed_segments, sub_spline
 from .waypoint_navigation import WaypointNavigation
 
 __all__ = [
     'DriveSegment',
+    'GnssRequirement',
+    'RecordedTrack',
+    'RecordedTrackNavigation',
+    'RecordedTrackProvider',
+    'RecordedWaypoint',
     'StraightLineNavigation',
+    'TrackRecordingController',
     'WaypointNavigation',
     'generate_three_point_turn',
     'is_reference_valid',

--- a/feldfreund_devkit/navigation/recorded_track.py
+++ b/feldfreund_devkit/navigation/recorded_track.py
@@ -1,0 +1,223 @@
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from typing import Any, Self
+from uuid import uuid4
+
+import rosys
+from nicegui import Event
+from rosys.geometry import GeoPose
+from rosys.hardware.gnss import GpsQuality
+
+
+class GnssRequirement(StrEnum):
+    """Minimum GPS quality required when recording waypoints."""
+    NONE = 'none'
+    GNSS = 'gnss'
+    RTK = 'rtk'
+
+    def is_met_by(self, gps_quality: GpsQuality | None) -> bool:
+        """Check whether the given GPS quality meets this requirement."""
+        if self == GnssRequirement.NONE:
+            return True
+        if gps_quality is None:
+            return False
+        if self == GnssRequirement.GNSS:
+            return gps_quality in {GpsQuality.DGPS, GpsQuality.PPS, GpsQuality.RTK_FIXED, GpsQuality.RTK_FLOAT}
+        return gps_quality == GpsQuality.RTK_FIXED
+
+
+@dataclass(slots=True, kw_only=True)
+class RecordedWaypoint:
+    """A waypoint with optional drive settings flags."""
+    pose: GeoPose
+    approach_reverse: bool = False
+    use_implement: bool = False
+    stop_at_waypoint: bool = False
+
+    @property
+    def degree_tuple(self):
+        return self.pose.point.degree_tuple
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            'pose': self.pose.degree_tuple,
+            'approach_reverse': self.approach_reverse,
+            'use_implement': self.use_implement,
+            'stop_at_waypoint': self.stop_at_waypoint,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> 'RecordedWaypoint':
+        return cls(
+            pose=GeoPose.from_degrees(*data['pose']),
+            approach_reverse=data.get('approach_reverse', False),
+            use_implement=data.get('use_implement', False),
+            stop_at_waypoint=data.get('stop_at_waypoint', False),
+        )
+
+
+class RecordedTrack:
+    """A track (basically a list of waypoints) that can be recorded and later navigated along."""
+
+    def __init__(self, name: str | None = None,) -> None:
+        self.id = str(uuid4())
+        self.name = name if name is not None else datetime.now().strftime('%Y-%m-%d_%H-%M-%S.%f')
+        self.gnss_requirement: GnssRequirement = GnssRequirement.RTK
+        self._waypoints: list[RecordedWaypoint] = []
+
+    def meets_gnss_requirement(self, gps_quality: GpsQuality | None) -> bool:
+        """Check whether the given GPS quality meets this track's minimum requirement."""
+        return self.gnss_requirement.is_met_by(gps_quality)
+
+    def add_waypoint(self, waypoint: GeoPose, approach_reverse: bool = False) -> None:
+        """Add a waypoint to the end of the list."""
+        self._waypoints.append(RecordedWaypoint(pose=waypoint, approach_reverse=approach_reverse))
+
+    def remove_waypoint(self, index: int) -> None:
+        """Remove a waypoint at the specified index."""
+        if not self._is_valid_index(index):
+            raise IndexError(f'Waypoint index {index} is out of bounds (track has {len(self._waypoints)} waypoints)')
+        self._waypoints.pop(index)
+
+    def move_waypoint(self, from_index: int, to_index: int) -> None:
+        """Move a waypoint from one position to another."""
+        if not self._is_valid_index(from_index):
+            raise IndexError(f'from_index {from_index} is out of bounds (track has {len(self._waypoints)} waypoints)')
+        if not self._is_valid_index(to_index):
+            raise IndexError(f'to_index {to_index} is out of bounds (track has {len(self._waypoints)} waypoints)')
+        waypoint = self._waypoints.pop(from_index)
+        self._waypoints.insert(to_index, waypoint)
+
+    def _is_valid_index(self, index: int) -> bool:
+        return 0 <= index < len(self._waypoints)
+
+    def get_waypoint(self, index: int) -> RecordedWaypoint:
+        """Get the waypoint at the given index, raising IndexError if out of bounds."""
+        if not self._is_valid_index(index):
+            raise IndexError(f'Waypoint index {index} is out of bounds (track has {len(self._waypoints)} waypoints)')
+        return self._waypoints[index]
+
+    def set_waypoint_approach_reverse(self, index: int, approach_reverse: bool) -> None:
+        """Set whether to approach the waypoint at the given index in reverse."""
+        self.get_waypoint(index).approach_reverse = approach_reverse
+
+    def set_waypoint_use_implement(self, index: int, use_implement: bool) -> None:
+        """Set whether to allow implement usage on the segment leading to this waypoint."""
+        self.get_waypoint(index).use_implement = use_implement
+
+    def set_waypoint_stop_at_waypoint(self, index: int, stop_at_waypoint: bool) -> None:
+        """Set whether to stop at this waypoint."""
+        self.get_waypoint(index).stop_at_waypoint = stop_at_waypoint
+
+    def clear(self) -> None:
+        """Remove all waypoints."""
+        self._waypoints.clear()
+
+    @property
+    def first_waypoint(self) -> RecordedWaypoint | None:
+        """Get the first waypoint."""
+        return self._waypoints[0] if self._waypoints else None
+
+    @property
+    def last_waypoint(self) -> RecordedWaypoint | None:
+        """Get the last waypoint."""
+        return self._waypoints[-1] if self._waypoints else None
+
+    @property
+    def waypoints(self) -> list[RecordedWaypoint]:
+        """Get the waypoints."""
+        return self._waypoints
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            'id': self.id,
+            'name': self.name,
+            'gnss_requirement': str(self.gnss_requirement),
+            'waypoints': [wp.to_dict() for wp in self.waypoints],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Self:
+        new_object = cls(data['name'])
+        new_object.id = data['id']
+        new_object.gnss_requirement = GnssRequirement(data.get('gnss_requirement', 'rtk'))
+        new_object._waypoints = [RecordedWaypoint.from_dict(wp) for wp in data.get('waypoints', [])]
+        return new_object
+
+
+class RecordedTrackProvider(rosys.persistence.Persistable):
+    """A provider of recorded waypoints."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.log = logging.getLogger('feldfreund_devkit.recorded_track_provider')
+        self.recorded_tracks: list[RecordedTrack] = []
+        self.selected_track: RecordedTrack | None = None
+
+        """The recorded tracks have changed."""
+        self.RECORDED_TRACKS_CHANGED: Event = Event()
+        """ The selected track has changed. """
+        self.RECORDED_TRACK_SELECTED: Event = Event()
+
+    def select_track(self, track_id: str) -> None:
+        """Select a track by ID."""
+        self.selected_track = self.get_recorded_track(track_id)
+        self.RECORDED_TRACK_SELECTED.emit()
+        self.request_backup()
+
+    def notify_track_modified(self) -> None:
+        """Persist changes to an existing track (e.g. waypoint added/removed/moved, name changed)."""
+        self.request_backup()
+
+    def remove_recorded_track(self, track_id: str) -> None:
+        """Remove a recorded track from the list."""
+        recorded_track = self.get_recorded_track(track_id)
+        if recorded_track is None:
+            self.log.warning('Track with ID %s not found', track_id)
+            return
+        self.recorded_tracks.remove(recorded_track)
+        if self.selected_track == recorded_track:
+            self.selected_track = None
+            self.RECORDED_TRACK_SELECTED.emit()
+        self.RECORDED_TRACKS_CHANGED.emit()
+        self.request_backup()
+
+    def get_recorded_track(self, track_id: str) -> RecordedTrack | None:
+        """Get the recorded track by ID."""
+        track = next((track for track in self.recorded_tracks if track.id == track_id), None)
+        if track is None:
+            self.log.warning('Track with ID %s not found', track_id)
+            return None
+        return track
+
+    def get_track_names_by_id(self) -> dict[str, str]:
+        """Get the track names by their IDs."""
+        return {track.id: track.name for track in self.recorded_tracks}
+
+    def add_recorded_track(self, track: RecordedTrack) -> None:
+        """Add a recorded track to the list."""
+        self.recorded_tracks.append(track)
+        self.RECORDED_TRACKS_CHANGED.emit()
+        self.request_backup()
+
+    def backup_to_dict(self) -> dict[str, Any]:
+        """Backup the recorded tracks to a dictionary."""
+        return {
+            'recorded_tracks': [
+                track.to_dict()
+                for track in self.recorded_tracks
+            ],
+            'selected_track': self.selected_track.id if self.selected_track else None,
+        }
+
+    def restore_from_dict(self, data: dict[str, Any]) -> None:
+        """Restore the recorded tracks from a dictionary."""
+        self.recorded_tracks.clear()
+        for track_data in data.get('recorded_tracks', []):
+            track = RecordedTrack.from_dict(track_data)
+            self.recorded_tracks.append(track)
+        selected_track_id = data.get('selected_track', None)
+        if selected_track_id is not None:
+            self.select_track(selected_track_id)

--- a/feldfreund_devkit/navigation/recorded_track_navigation.py
+++ b/feldfreund_devkit/navigation/recorded_track_navigation.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import contextlib
+import logging
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+import rosys
+from nicegui import ui
+from rosys.automation import Automator
+from rosys.geometry import Pose, Spline
+from rosys.hardware import Gnss
+
+from .drive_segment import DriveSegment
+from .recorded_track import GnssRequirement, RecordedTrack, RecordedTrackProvider
+from .track_recording_controller import TrackRecordingController
+from .utils import skip_completed_segments
+from .waypoint_navigation import WaypointNavigation
+
+if TYPE_CHECKING:
+    from ..interface.components.track_recorder_dialog import TrackRecorderDialog
+
+
+class RecordedTrackNavigation(WaypointNavigation):
+    """Drives along a previously recorded track of waypoints."""
+
+    # Boundaries when starting the mid of track is allowed.
+    RESUME_MAX_OFFSET: float = 2.0           # meters, perpendicular to path
+    RESUME_MAX_HEADING: float = np.deg2rad(45)
+
+    def __init__(self, *,
+                 recorded_track_provider: RecordedTrackProvider,
+                 track_recording_controller: TrackRecordingController,
+                 gnss: Gnss | None = None,
+                 automator: Automator | None = None,
+                 **kwargs) -> None:
+        super().__init__(**kwargs, name='Recorded Track Navigation')
+        self.recorded_track_provider = recorded_track_provider
+        self.track_recording_controller = track_recording_controller
+        self.gnss = gnss
+        self.automator = automator
+        self.reverse: bool = False
+        # Live waypoint count is patched directly into this label to avoid refreshing
+        # the banner on every waypoint, which would disturb sibling elements.
+        self._banner_count_label: ui.label | None = None
+        self._settings_content_row: ui.column | None = None
+        self._dialog_host: ui.element | None = None
+        self._current_recorder: TrackRecorderDialog | None = None
+
+        self.recorded_track_provider.RECORDED_TRACK_SELECTED.subscribe(self._settings_content.refresh)
+        self.recorded_track_provider.RECORDED_TRACKS_CHANGED.subscribe(self._settings_content.refresh)
+        self.track_recording_controller.RECORDING_STARTED.subscribe(self._recording_banner.refresh)
+        self.track_recording_controller.RECORDING_STARTED.subscribe(lambda: self._set_settings_visible(False))
+        self.track_recording_controller.RECORDING_STOPPED.subscribe(self._recording_banner.refresh)
+        self.track_recording_controller.RECORDING_STOPPED.subscribe(lambda: self._set_settings_visible(True))
+        self.track_recording_controller.WAYPOINT_ADDED.subscribe(self._update_banner_count)
+
+    async def prepare(self) -> bool:
+        if not await super().prepare():
+            return False
+        selected_track = self.recorded_track_provider.selected_track
+        if selected_track is not None and selected_track.gnss_requirement != GnssRequirement.NONE:
+            measurement = self.gnss.last_measurement if self.gnss else None
+            if not selected_track.meets_gnss_requirement(measurement.gps_quality if measurement else None):
+                rosys.notify('GNSS quality insufficient for this track', 'negative')
+                self.log.warning('Navigation not started: GNSS requirement %s not met', selected_track.gnss_requirement)
+                return False
+        return True
+
+    def generate_path(self) -> list[DriveSegment]:
+        recorded_track = self.recorded_track_provider.selected_track
+        if recorded_track is None:
+            raise ValueError('No track selected')
+        waypoints = recorded_track.waypoints
+        path_segments: list[DriveSegment] = []
+        for i in range(1, len(waypoints)):
+            start_pose = waypoints[i - 1].pose.to_local()
+            end_pose = waypoints[i].pose.to_local()
+            backward = waypoints[i].approach_reverse
+            spline = Spline.from_poses(start_pose, end_pose, backward=backward)
+            is_last_segment = i == len(waypoints) - 1
+            path_segments.append(DriveSegment(
+                spline=spline,
+                backward=backward,
+                use_implement=waypoints[i].use_implement,
+                stop_at_end=waypoints[i].stop_at_waypoint or is_last_segment,
+            ))
+        if self.reverse:
+            forward_segments = list(path_segments)
+            path_segments = []
+            for j in range(len(forward_segments) - 1, -1, -1):
+                seg = forward_segments[j]
+                yaw_offset = 0.0 if seg.backward else math.pi
+                is_last_reversed = j == 0
+                path_segments.append(DriveSegment.from_poses(
+                    Pose(x=seg.end.x, y=seg.end.y, yaw=seg.end.yaw + yaw_offset),
+                    Pose(x=seg.start.x, y=seg.start.y, yaw=seg.start.yaw + yaw_offset),
+                    backward=seg.backward,
+                    use_implement=seg.use_implement,
+                    stop_at_end=seg.stop_at_end or is_last_reversed,
+                ))
+        path_segments = skip_completed_segments(self.pose_provider.pose, path_segments,
+                                                max_distance=self.RESUME_MAX_OFFSET, max_angle=self.RESUME_MAX_HEADING)
+        if not path_segments:
+            rosys.notify(
+                f'Align the robot with the track (within {self.RESUME_MAX_OFFSET:.1f} m and '
+                f'{np.rad2deg(self.RESUME_MAX_HEADING):.0f}°)',
+                'negative', log_level=logging.ERROR)
+        return path_segments
+
+    async def approach_start(self) -> None:
+        """Approaches the start of the track directly.
+
+        Use with caution, alignment with the track will not be checked.
+        If reverse is enabled, the robot will approach the end of the track instead.
+        """
+        recorded_track = self.recorded_track_provider.selected_track
+        if recorded_track is None:
+            raise ValueError('No track selected')
+        start_index = -1 if self.reverse else 0
+        start_pose = recorded_track.waypoints[start_index].pose.to_local()
+        if self.reverse:
+            start_pose = start_pose.rotate(math.pi)
+        spline = Spline.from_poses(self.pose_provider.pose, start_pose)
+        with self.driver.parameters.set(linear_speed_limit=self.linear_speed_limit):
+            await self.driver.drive_spline(spline)
+
+    def settings_ui(self) -> None:
+        super().settings_ui()
+        self._recording_banner()  # type: ignore[call-arg]
+        self._settings_content_row = ui.column().classes('w-full gap-2')
+        with self._settings_content_row:
+            self._settings_content()  # type: ignore[call-arg]
+        # Stable host for dialogs so settings refreshes don't tear them down.
+        self._dialog_host = ui.element('div')
+        self._set_settings_visible(not self.track_recording_controller.is_recording)
+
+    @ui.refreshable
+    def _settings_content(self) -> None:
+        provider = self.recorded_track_provider
+        selected = provider.selected_track
+        with ui.row():
+            ui.select(
+                value=selected.id if selected else None,
+                options={t.id: t.name for t in provider.recorded_tracks},
+                label='Select Recorded Track',
+                on_change=lambda e: provider.select_track(e.value)) \
+                .style('min-width: 300px')
+            ui.button(icon='add', on_click=self.start_new_track_recording) \
+                .tooltip('Create a new track and start recording')
+        with ui.row():
+            ui.button(icon='edit', on_click=self.start_track_editing) \
+                .tooltip('Open dialog to edit selected track') \
+                .bind_enabled_from(provider, 'selected_track', lambda t: t is not None)
+            ui.button(icon='fiber_manual_record', on_click=self.resume_track_recording) \
+                .tooltip('Resume recording into selected track') \
+                .bind_enabled_from(provider, 'selected_track', lambda t: t is not None)
+            ui.button(icon='moving', on_click=self._start_approach) \
+                .tooltip('Approach start of selected track. Use with caution!') \
+                .bind_enabled_from(provider, 'selected_track', lambda t: t is not None)
+            ui.checkbox('Reverse direction').bind_value(self, 'reverse')
+
+    @ui.refreshable
+    def _recording_banner(self) -> None:
+        active_track = self.track_recording_controller.active_track
+        if active_track is None:
+            self._banner_count_label = None
+            return
+        with ui.row().classes('w-full items-center bg-orange-100 rounded p-2 gap-2'):
+            with ui.row():
+                ui.icon('fiber_manual_record').classes('text-red-600 animate-pulse')
+                self._banner_count_label = ui.label(self._banner_text(active_track)).classes('text-sm')
+            with ui.row():
+                ui.button('Open recorder', on_click=self.open_recorder).props('flat dense')
+                ui.button('Stop recording', on_click=self.track_recording_controller.stop_recording, color='red') \
+                    .props('flat dense')
+
+    @staticmethod
+    def _banner_text(active_track: RecordedTrack) -> str:
+        return f'Recording: {active_track.name} ({len(active_track.waypoints)} waypoints)'
+
+    def _update_banner_count(self) -> None:
+        active_track = self.track_recording_controller.active_track
+        label = self._banner_count_label
+        if active_track is None or label is None or label.is_deleted:
+            return
+        label.set_text(self._banner_text(active_track))
+
+    def _set_settings_visible(self, visible: bool) -> None:
+        if self._settings_content_row is not None:
+            self._settings_content_row.set_visibility(visible)
+
+    def _start_approach(self) -> None:
+        if self.automator is None:
+            return
+        self.automator.start(self.approach_start())
+
+    async def start_new_track_recording(self) -> None:
+        await self.track_recording_controller.start_recording(RecordedTrack())
+
+    async def resume_track_recording(self) -> None:
+        selected = self.recorded_track_provider.selected_track
+        if selected is None:
+            return
+        await self.track_recording_controller.start_recording(selected)
+
+    def start_track_editing(self) -> None:
+        selected = self.recorded_track_provider.selected_track
+        if selected is None:
+            return
+        self._open_recorder(selected)
+
+    def open_recorder(self) -> None:
+        active_track = self.track_recording_controller.active_track
+        if active_track is None:
+            return
+        self._open_recorder(active_track)
+
+    def _open_recorder(self, active_track: RecordedTrack) -> None:
+        # Imported lazily to avoid an import cycle: the dialog lives in
+        # ``interface.components`` which imports back into this package.
+        # pylint: disable=import-outside-toplevel
+        from ..interface.components.track_recorder_dialog import TrackRecorderDialog  # noqa: PLC0415
+        # Build inside the stable dialog host so settings refreshes don't tear the dialog down.
+        host = self._dialog_host if self._dialog_host is not None else contextlib.nullcontext()
+        with host:
+            self._current_recorder = TrackRecorderDialog(
+                existing_track=active_track,
+                recorded_track_provider=self.recorded_track_provider,
+                track_recording_controller=self.track_recording_controller,
+                pose_provider=self.pose_provider,
+                gnss=self.gnss)

--- a/feldfreund_devkit/navigation/recorded_track_navigation.py
+++ b/feldfreund_devkit/navigation/recorded_track_navigation.py
@@ -34,12 +34,15 @@ class RecordedTrackNavigation(WaypointNavigation):
                  track_recording_controller: TrackRecordingController,
                  gnss: Gnss | None = None,
                  automator: Automator | None = None,
+                 robot_marker_icon_url: str | None = None,
                  **kwargs) -> None:
         super().__init__(**kwargs, name='Recorded Track Navigation')
         self.recorded_track_provider = recorded_track_provider
         self.track_recording_controller = track_recording_controller
         self.gnss = gnss
         self.automator = automator
+        # Robot marker image shown on the recorder map; None falls back to Leaflet's default marker.
+        self.robot_marker_icon_url = robot_marker_icon_url
         self.reverse: bool = False
         # Live waypoint count is patched directly into this label to avoid refreshing
         # the banner on every waypoint, which would disturb sibling elements.
@@ -230,4 +233,5 @@ class RecordedTrackNavigation(WaypointNavigation):
                 recorded_track_provider=self.recorded_track_provider,
                 track_recording_controller=self.track_recording_controller,
                 pose_provider=self.pose_provider,
-                gnss=self.gnss)
+                gnss=self.gnss,
+                robot_marker_icon_url=self.robot_marker_icon_url)

--- a/feldfreund_devkit/navigation/track_recording_controller.py
+++ b/feldfreund_devkit/navigation/track_recording_controller.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import logging
+from typing import Protocol, runtime_checkable
+
+import rosys
+from nicegui import Event
+from rosys.automation import AppButton
+from rosys.driving.driver import PoseProvider
+from rosys.geometry import GeoPose
+from rosys.hardware import Gnss
+
+from .recorded_track import RecordedTrack, RecordedTrackProvider
+
+log = logging.getLogger('feldfreund_devkit.track_recording_controller')
+
+
+@runtime_checkable
+class AppButtonControls(Protocol):
+    """Minimal interface for the bluetooth-app button bar the controller needs."""
+
+    async def add_button(self, key: str, button: AppButton) -> None: ...
+
+    async def remove_button(self, key: str) -> None: ...
+
+
+class TrackRecordingController:
+    """Server-side recording mode that survives client disconnects.
+
+    Owns the bluetooth-app waypoint button so the operator can keep adding
+    waypoints even if the browser/dialog is gone.
+
+    The app button bar (``app_controls``) is bound late: it is created by the
+    application after this controller and only on real hardware, so it stays
+    ``None`` until assigned and the button registration is skipped while absent.
+    """
+
+    APP_BUTTON_KEY = 'record_waypoint'
+
+    def __init__(self, recorded_track_provider: RecordedTrackProvider, *,
+                 pose_provider: PoseProvider, gnss: Gnss | None = None) -> None:
+        self.recorded_track_provider = recorded_track_provider
+        self.pose_provider = pose_provider
+        self.gnss = gnss
+        self.app_controls: AppButtonControls | None = None
+        self._active_track: RecordedTrack | None = None
+        self._track_was_new: bool = False
+        self._started_at: float | None = None
+
+        self.RECORDING_STARTED: Event = Event()
+        self.RECORDING_STOPPED: Event = Event()
+        self.WAYPOINT_ADDED: Event = Event()
+
+    @property
+    def active_track(self) -> RecordedTrack | None:
+        return self._active_track
+
+    @property
+    def is_recording(self) -> bool:
+        return self._active_track is not None
+
+    @property
+    def started_at(self) -> float | None:
+        return self._started_at
+
+    @property
+    def elapsed_seconds(self) -> float:
+        return 0.0 if self._started_at is None else max(0.0, rosys.time() - self._started_at)
+
+    async def start_recording(self, track: RecordedTrack) -> bool:
+        """Start a recording session. Returns False if a session is already active.
+
+        Persists the track immediately (so it survives a server crash) without
+        emitting `RECORDED_TRACKS_CHANGED` — that event refreshes the settings UI
+        which would tear down a dialog opened from there. Stop emits it instead.
+        """
+        if self._active_track is not None:
+            rosys.notify('A recording is already in progress', 'warning')
+            return False
+        provider = self.recorded_track_provider
+        if track not in provider.recorded_tracks:
+            provider.recorded_tracks.append(track)
+            self._track_was_new = True
+        else:
+            self._track_was_new = False
+        provider.request_backup()
+        self._active_track = track
+        self._started_at = rosys.time()
+        await self._register_app_button()
+        self.RECORDING_STARTED.emit()
+        log.info('Recording started for track %s (%s)', track.name, track.id)
+        return True
+
+    async def stop_recording(self) -> None:
+        """Stop the active recording. Idempotent."""
+        if self._active_track is None:
+            return
+        track = self._active_track
+        was_new = self._track_was_new
+        self._active_track = None
+        self._track_was_new = False
+        self._started_at = None
+        await self._unregister_app_button()
+        # Close any open dialog first; only then refresh the settings panel
+        # (settings refresh would otherwise tear down the dialog mid-close).
+        self.RECORDING_STOPPED.emit()
+        provider = self.recorded_track_provider
+        provider.RECORDED_TRACKS_CHANGED.emit()
+        if was_new:
+            provider.select_track(track.id)
+        log.info('Recording stopped for track %s (%s)', track.name, track.id)
+
+    async def add_waypoint_at_current_pose(self) -> None:
+        """Append the robot's current pose as a waypoint to the active track.
+
+        Returns without adding if not recording or if the GNSS quality is
+        insufficient. The GNSS case notifies the operator (forwarded to both
+        browser clients and the bluetooth app via `rosys.NEW_NOTIFICATION`).
+        """
+        if self._active_track is None:
+            log.warning('Waypoint not added: no active recording')
+            return
+        if not self._meets_gnss_requirement(self._active_track):
+            rosys.notify('Waypoint not added: GNSS quality insufficient', 'warning')
+            return
+        geo_pose = GeoPose.from_pose(self.pose_provider.pose)
+        self._active_track.add_waypoint(geo_pose)
+        self.recorded_track_provider.notify_track_modified()
+        self.WAYPOINT_ADDED.emit()
+        log.info('Waypoint %d added at %s', len(self._active_track.waypoints), geo_pose)
+
+    def _meets_gnss_requirement(self, track: RecordedTrack) -> bool:
+        if self.gnss is None:
+            return True
+        measurement = self.gnss.last_measurement
+        gps_quality = measurement.gps_quality if measurement else None
+        return track.meets_gnss_requirement(gps_quality)
+
+    async def _register_app_button(self) -> None:
+        if self.app_controls is None:
+            return
+        await self.app_controls.add_button(
+            self.APP_BUTTON_KEY,
+            AppButton('add_location', released=self.add_waypoint_at_current_pose),  # type: ignore[arg-type]
+        )
+
+    async def _unregister_app_button(self) -> None:
+        if self.app_controls is None:
+            return
+        await self.app_controls.remove_button(self.APP_BUTTON_KEY)

--- a/main.py
+++ b/main.py
@@ -7,7 +7,13 @@ from rosys.driving import Driver, Steerer, keyboard_control, robot_object
 import feldfreund_devkit
 from feldfreund_devkit.config import FeldfreundConfiguration, Secrets, config_from_id
 from feldfreund_devkit.implement import ImplementDummy
-from feldfreund_devkit.navigation import StraightLineNavigation
+from feldfreund_devkit.navigation import (
+    RecordedTrackNavigation,
+    RecordedTrackProvider,
+    StraightLineNavigation,
+    TrackRecordingController,
+    WaypointNavigation,
+)
 
 
 class System(feldfreund_devkit.System):
@@ -16,11 +22,32 @@ class System(feldfreund_devkit.System):
         self.steerer = Steerer(self.feldfreund.wheels, speed_scaling=0.25)
         self.driver = Driver(self.feldfreund.wheels, self.odometer, parameters=self.config.driver)
         self.shape = rosys.geometry.Prism.default_robot_shape()
-        self.navigation = StraightLineNavigation(implement=ImplementDummy(),
-                                                 driver=self.driver,
-                                                 pose_provider=self.odometer)
         self.automator = Automator(self.steerer, on_interrupt=self.feldfreund.stop, notify=False)
-        self.automator.default_automation = self.navigation.start
+
+        self.recorded_track_provider = RecordedTrackProvider().persistent()
+        self.track_recording_controller = TrackRecordingController(
+            self.recorded_track_provider, pose_provider=self.odometer, gnss=self.feldfreund.gnss)
+
+        common = {'implement': ImplementDummy(), 'driver': self.driver, 'pose_provider': self.odometer}
+        self.navigations: dict[str, WaypointNavigation] = {n.name: n for n in [
+            StraightLineNavigation(**common),
+            RecordedTrackNavigation(recorded_track_provider=self.recorded_track_provider,
+                                    track_recording_controller=self.track_recording_controller,
+                                    gnss=self.feldfreund.gnss,
+                                    automator=self.automator,
+                                    **common),
+        ]}
+        self._current_navigation: WaypointNavigation = next(iter(self.navigations.values()))
+        self.automator.default_automation = self._current_navigation.start
+
+    @property
+    def current_navigation(self) -> WaypointNavigation:
+        return self._current_navigation
+
+    @current_navigation.setter
+    def current_navigation(self, navigation: WaypointNavigation) -> None:
+        self._current_navigation = navigation
+        self.automator.default_automation = navigation.start
 
 
 def startup() -> None:
@@ -33,10 +60,21 @@ def startup() -> None:
         keyboard_control(system.steerer)
         with ui.scene():
             robot_object(system.shape, system.odometer)
+
+        @ui.refreshable
+        def navigation_settings() -> None:
+            system.current_navigation.settings_ui()
+
+        def select_navigation(name: str) -> None:
+            system.current_navigation = system.navigations[name]
+            navigation_settings.refresh()
+
         with ui.card():
             ui.label('hold SHIFT to steer with the keyboard arrow keys or use the automation controls')
+            ui.select(list(system.navigations), value=system.current_navigation.name, label='Navigation',
+                      on_change=lambda e: select_navigation(e.value)).classes('w-64')
             with ui.row():
-                system.navigation.settings_ui()
+                navigation_settings()
             with ui.row():
                 automation_controls(system.automator)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,12 @@ from rosys.testing import forward, helpers
 from feldfreund_devkit.config import Secrets, config_from_id, create_drive_parameters
 from feldfreund_devkit.hardware.tracks import TracksSimulation
 from feldfreund_devkit.implement import ImplementDummy
-from feldfreund_devkit.navigation import StraightLineNavigation
+from feldfreund_devkit.navigation import (
+    RecordedTrackNavigation,
+    RecordedTrackProvider,
+    StraightLineNavigation,
+    TrackRecordingController,
+)
 from feldfreund_devkit.robot_locator import RobotLocator
 from feldfreund_devkit.system import System
 
@@ -53,6 +58,23 @@ class TestSystem(System):
                                                          driver=self.driver,
                                                          pose_provider=self.robot_locator)
         self.automator.default_automation = self.current_navigation.start
+
+        self.recorded_track_provider = RecordedTrackProvider()
+        self.track_recording_controller = TrackRecordingController(
+            self.recorded_track_provider, pose_provider=self.robot_locator, gnss=self.feldfreund.gnss)
+        self.recorded_track_navigation = RecordedTrackNavigation(
+            recorded_track_provider=self.recorded_track_provider,
+            track_recording_controller=self.track_recording_controller,
+            gnss=self.feldfreund.gnss,
+            automator=self.automator,
+            implement=self.current_implement,
+            driver=self.driver,
+            pose_provider=self.robot_locator)
+
+    def use_recorded_track_navigation(self) -> None:
+        """Activate recorded-track navigation as the default automation."""
+        self.current_navigation = self.recorded_track_navigation
+        self.automator.default_automation = self.recorded_track_navigation.start
 
     def set_robot_pose(self, pose: Pose):
         # pylint: disable=protected-access

--- a/tests/test_recorded_track.py
+++ b/tests/test_recorded_track.py
@@ -1,0 +1,261 @@
+import math
+
+import pytest
+from conftest import GEO_REFERENCE
+from rosys.geometry import GeoPose, GeoReference, Pose
+from rosys.hardware.gnss import GpsQuality
+from rosys.helpers import angle
+from rosys.testing import forward
+
+from feldfreund_devkit.navigation import (
+    DriveSegment,
+    GnssRequirement,
+    RecordedTrack,
+    RecordedTrackNavigation,
+    RecordedWaypoint,
+    generate_three_point_turn,
+)
+
+_LAT_DEG = math.degrees(GEO_REFERENCE.origin.lat)
+_LON_DEG = math.degrees(GEO_REFERENCE.origin.lon)
+
+
+def _make_waypoint(*, lat_offset: float = 0.0, approach_reverse: bool = False,
+                   use_implement: bool = False, stop_at_waypoint: bool = False) -> RecordedWaypoint:
+    return RecordedWaypoint(
+        pose=GeoPose.from_degrees(_LAT_DEG + lat_offset, _LON_DEG, 0.0),
+        approach_reverse=approach_reverse,
+        use_implement=use_implement,
+        stop_at_waypoint=stop_at_waypoint,
+    )
+
+
+def _make_track(waypoints: list[dict] | None = None) -> RecordedTrack:
+    """Build a RecordedTrack with one waypoint per dict of keyword arguments."""
+    track = RecordedTrack(name='test')
+    for i, kwargs in enumerate(waypoints or [{}]):
+        track._waypoints.append(_make_waypoint(lat_offset=i * 0.00001, **kwargs))
+    return track
+
+
+@pytest.fixture
+def three_point_turn_track(devkit_system) -> RecordedTrack:
+    """Three-point turn (0,0,0) to (0,1,180) plus a straight implement segment to (-2,1,180)."""
+    assert GeoReference.current is not None
+    track = RecordedTrack(name='three-point-turn')
+    track._waypoints = [
+        RecordedWaypoint(pose=GeoPose.from_pose(Pose(x=0.0, y=0.0, yaw=0.0))),
+        RecordedWaypoint(pose=GeoPose.from_pose(Pose(x=1.500, y=1.500, yaw=math.radians(90.0)))),
+        RecordedWaypoint(pose=GeoPose.from_pose(
+            Pose(x=1.500, y=-0.500, yaw=math.radians(90.0))), approach_reverse=True),
+        RecordedWaypoint(pose=GeoPose.from_pose(Pose(x=0.000, y=1.000, yaw=math.radians(180.0)))),
+        RecordedWaypoint(pose=GeoPose.from_pose(Pose(x=-1.0, y=1.0, yaw=math.pi)), use_implement=True),
+        RecordedWaypoint(pose=GeoPose.from_pose(Pose(x=-2.0, y=1.0, yaw=math.pi))),
+    ]
+    devkit_system.recorded_track_provider.recorded_tracks.append(track)
+    devkit_system.recorded_track_provider.selected_track = track
+    devkit_system.use_recorded_track_navigation()
+    return track
+
+
+# ---------------------------------------------------------------------------
+# Pure-unit tests — RecordedWaypoint / RecordedTrack (no fixtures)
+# ---------------------------------------------------------------------------
+
+def test_roundtrip_serialization():
+    track = _make_track([
+        {'approach_reverse': False, 'use_implement': True, 'stop_at_waypoint': True},
+        {'approach_reverse': True, 'use_implement': False, 'stop_at_waypoint': False},
+        {},  # will use defaults
+    ])
+    restored = RecordedTrack.from_dict(track.to_dict())
+    assert restored.waypoints[0].approach_reverse is False
+    assert restored.waypoints[0].use_implement is True
+    assert restored.waypoints[0].stop_at_waypoint is True
+    assert restored.waypoints[1].approach_reverse is True
+    assert restored.waypoints[1].use_implement is False
+    assert restored.waypoints[1].stop_at_waypoint is False
+    # check defaults
+    assert restored.waypoints[2].approach_reverse is False
+    assert restored.waypoints[2].use_implement is False
+    assert restored.waypoints[2].stop_at_waypoint is False
+
+
+def test_gnss_requirement_serialization():
+    for requirement in GnssRequirement:
+        track = _make_track([{}])
+        track.gnss_requirement = requirement
+        restored = RecordedTrack.from_dict(track.to_dict())
+        assert restored.gnss_requirement == requirement
+
+
+def test_gnss_requirement_defaults_to_rtk():
+    track = _make_track([{}])
+    data = track.to_dict()
+    del data['gnss_requirement']
+    restored = RecordedTrack.from_dict(data)
+    assert restored.gnss_requirement == GnssRequirement.RTK
+
+
+def test_meets_gnss_requirement():
+    track = RecordedTrack(name='test')
+
+    track.gnss_requirement = GnssRequirement.NONE
+    assert track.meets_gnss_requirement(None) is True
+    assert track.meets_gnss_requirement(GpsQuality.INVALID) is True
+    assert track.meets_gnss_requirement(GpsQuality.GPS) is True
+
+    track.gnss_requirement = GnssRequirement.GNSS
+    assert track.meets_gnss_requirement(None) is False
+    assert track.meets_gnss_requirement(GpsQuality.INVALID) is False
+    assert track.meets_gnss_requirement(GpsQuality.GPS) is False
+    assert track.meets_gnss_requirement(GpsQuality.DGPS) is True
+    assert track.meets_gnss_requirement(GpsQuality.RTK_FIXED) is True
+    assert track.meets_gnss_requirement(GpsQuality.RTK_FLOAT) is True
+
+    track.gnss_requirement = GnssRequirement.RTK
+    assert track.meets_gnss_requirement(None) is False
+    assert track.meets_gnss_requirement(GpsQuality.DGPS) is False
+    assert track.meets_gnss_requirement(GpsQuality.RTK_FLOAT) is False
+    assert track.meets_gnss_requirement(GpsQuality.RTK_FIXED) is True
+
+
+def test_reversed_three_point_turn_headings(three_point_turn_track: RecordedTrack):
+    """All headings are rotated 180° when reversing, regardless of approach_reverse."""
+    forward_yaws = [wp.pose.to_local().yaw for wp in three_point_turn_track.waypoints]
+    reversed_waypoints = list(reversed(three_point_turn_track.waypoints))
+    for i, wp in enumerate(reversed_waypoints):
+        original_idx = len(three_point_turn_track.waypoints) - 1 - i
+        reversed_yaw = wp.pose.to_local().yaw + math.pi
+        assert reversed_yaw == pytest.approx(forward_yaws[original_idx] + math.pi, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — forward and reversed three-point-turn track with working segments before and after
+# ---------------------------------------------------------------------------
+
+async def test_three_point_turn_headings(devkit_system, three_point_turn_track: RecordedTrack):
+    assert isinstance(devkit_system.current_navigation, RecordedTrackNavigation)
+    test_poses = []
+
+    def record_pose():
+        pose = Pose(x=devkit_system.robot_locator.pose.point.x,
+                    y=devkit_system.robot_locator.pose.point.y,
+                    yaw=devkit_system.robot_locator.pose.yaw)
+        test_poses.append(pose)
+    devkit_system.automator.start()
+    devkit_system.recorded_track_navigation.SEGMENT_COMPLETED.subscribe(record_pose)
+    await forward(until=lambda: devkit_system.automator.is_running)
+    await forward(until=lambda: devkit_system.automator.is_stopped)
+
+    assert test_poses[0].x == pytest.approx(1.5, abs=0.05)
+    assert test_poses[0].y == pytest.approx(1.5, abs=0.05)
+    assert test_poses[0].yaw_deg == pytest.approx(90.0, abs=2.0)
+
+    assert test_poses[1].x == pytest.approx(1.5, abs=0.05)
+    assert test_poses[1].y == pytest.approx(-0.5, abs=0.05)
+    assert test_poses[1].yaw_deg == pytest.approx(90.0, abs=2.0)
+
+    assert test_poses[2].x == pytest.approx(0.0, abs=0.05)
+    assert test_poses[2].y == pytest.approx(1.0, abs=0.05)
+    assert test_poses[2].yaw_deg == pytest.approx(180.0, abs=2.0)
+
+
+@pytest.mark.parametrize('reverse', (False, True))
+async def test_approach_recorded_track(devkit_system, three_point_turn_track: RecordedTrack, reverse: bool):
+    assert isinstance(devkit_system.current_navigation, RecordedTrackNavigation)
+    devkit_system.recorded_track_navigation.reverse = reverse
+    devkit_system.automator.start(devkit_system.recorded_track_navigation.approach_start())
+    if reverse:
+        expected_pose = three_point_turn_track.waypoints[-1].pose.to_local().rotate(math.pi)
+        devkit_system.set_robot_pose(Pose(x=-3.0, y=1.0, yaw=math.pi))
+    else:
+        expected_pose = three_point_turn_track.waypoints[0].pose.to_local()
+        devkit_system.set_robot_pose(Pose(x=-1.0, y=0.0, yaw=0.0))
+    await forward(until=lambda: devkit_system.automator.is_running)
+    await forward(until=lambda: devkit_system.automator.is_stopped)
+    assert devkit_system.robot_locator.pose.point.x == pytest.approx(expected_pose.x, abs=0.1)
+    assert devkit_system.robot_locator.pose.point.y == pytest.approx(expected_pose.y, abs=0.1)
+    assert angle(expected_pose.yaw, devkit_system.robot_locator.pose.yaw) == pytest.approx(0, abs=math.radians(0.5))
+
+
+@pytest.mark.parametrize('reverse', (False, True))
+async def test_recorded_track_navigation(devkit_system, reverse: bool):
+    """Robot drives a three-point-turn track with implement segments in both directions."""
+    if reverse:
+        start_pose = Pose(x=0.0, y=3.0, yaw=0.0)
+        end_pose = Pose(x=1.0, y=0.0, yaw=math.pi)
+        devkit_system.set_robot_pose(start_pose)
+        segments = [
+            DriveSegment.from_poses(Pose(x=1.0, y=3.0, yaw=0.0),
+                                    Pose(x=2.0, y=3.0, yaw=0.0),
+                                    use_implement=True),
+            *generate_three_point_turn(Pose(x=2.0, y=3.0, yaw=0.0),
+                                       Pose(x=2.0, y=1.0, yaw=math.pi)),
+            DriveSegment.from_poses(Pose(x=2.0, y=1.0, yaw=math.pi),
+                                    Pose(x=1.0, y=0.0, yaw=math.pi),
+                                    use_implement=True,
+                                    stop_at_end=True)
+        ]
+
+    else:
+        start_pose = Pose(x=0.0, y=0.0, yaw=0.0)
+        end_pose = Pose(x=1.0, y=3.0, yaw=math.pi)
+        segments = [
+            DriveSegment.from_poses(Pose(x=1.0, y=0.0, yaw=0.0),
+                                    Pose(x=2.0, y=1.0, yaw=0.0),
+                                    use_implement=True,
+                                    stop_at_end=False),
+            *generate_three_point_turn(Pose(x=2.0, y=1.0, yaw=0.0),
+                                       Pose(x=2.0, y=3.0, yaw=math.pi)),
+            DriveSegment.from_poses(Pose(x=2.0, y=3.0, yaw=math.pi),
+                                    Pose(x=1.0, y=3.0, yaw=math.pi),
+                                    use_implement=True,
+                                    stop_at_end=True)
+        ]
+
+    waypoints = [
+        RecordedWaypoint(pose=GeoPose(lat=0.9072805071005496, lon=0.12975200842318343, heading=0.0)),
+        RecordedWaypoint(pose=GeoPose(lat=0.9072806640617644, lon=0.1297517535706485, heading=0.0),
+                         use_implement=True),
+        RecordedWaypoint(pose=GeoPose(lat=0.9072808995035275, lon=0.12975137129165418, heading=-math.pi / 2),
+                         stop_at_waypoint=True),
+        RecordedWaypoint(pose=GeoPose(lat=0.9072808995035905, lon=0.12975162614426589, heading=-math.pi / 2),
+                         stop_at_waypoint=True, approach_reverse=True),
+        RecordedWaypoint(pose=GeoPose(lat=0.9072806640616384, lon=0.1297512438655786, heading=-math.pi),
+                         stop_at_waypoint=True),
+        RecordedWaypoint(pose=GeoPose(lat=0.9072805071004079, lon=0.1297512438657321, heading=-math.pi),
+                         use_implement=True),
+    ]
+
+    track = RecordedTrack(name='three-point-turn')
+    track._waypoints = waypoints  # pylint: disable=protected-access
+    devkit_system.recorded_track_provider.recorded_tracks.append(track)
+    devkit_system.recorded_track_provider.selected_track = track
+    devkit_system.use_recorded_track_navigation()
+    assert isinstance(devkit_system.current_navigation, RecordedTrackNavigation)
+    devkit_system.recorded_track_navigation.reverse = reverse
+
+    assert devkit_system.robot_locator.pose.point.x == pytest.approx(start_pose.x, abs=0.1)
+    assert devkit_system.robot_locator.pose.point.y == pytest.approx(start_pose.y, abs=0.1)
+    assert devkit_system.robot_locator.pose.yaw == pytest.approx(start_pose.yaw, abs=0.1)
+    devkit_system.automator.start()
+    await forward(until=lambda: devkit_system.automator.is_running)
+    assert len(devkit_system.recorded_track_navigation.path) == len(segments)
+
+    for i, segment in enumerate(segments):
+        path = devkit_system.recorded_track_navigation.path
+        assert path[i].start.x == pytest.approx(segment.start.x, abs=0.1)
+        assert path[i].start.y == pytest.approx(segment.start.y, abs=0.1)
+        assert path[i].start.yaw == pytest.approx(segment.start.yaw, abs=0.1)
+        assert path[i].end.x == pytest.approx(segment.end.x, abs=0.1)
+        assert path[i].end.y == pytest.approx(segment.end.y, abs=0.1)
+        assert path[i].end.yaw == pytest.approx(segment.end.yaw, abs=0.1)
+        assert path[i].use_implement == segment.use_implement
+        assert path[i].stop_at_end == segment.stop_at_end
+        assert path[i].backward == segment.backward
+
+    await forward(until=lambda: devkit_system.automator.is_stopped, timeout=120)
+    assert devkit_system.robot_locator.pose.point.x == pytest.approx(end_pose.x, abs=0.1)
+    assert devkit_system.robot_locator.pose.point.y == pytest.approx(end_pose.y, abs=0.1)
+    assert angle(end_pose.yaw, devkit_system.robot_locator.pose.yaw) == pytest.approx(0, abs=0.1)


### PR DESCRIPTION
### Motivation

Recorded-track navigation (record GNSS waypoints, then drive/replay the track) lived only in an internal repo. Moving it into the devkit lets every robot project built on the devkit reuse it, following the existing `StraightLineNavigation` split — core logic here, thin app wrapper in the consuming app.

### Implementation

- Add `navigation/recorded_track.py`: `RecordedTrack`, `RecordedWaypoint`, `RecordedTrackProvider`, `GnssRequirement`
- Add `navigation/track_recording_controller.py`: `TrackRecordingController`, decoupled from `System` (explicit `recorded_track_provider`/`pose_provider`/`gnss` deps + late-bound app-button `Protocol`)
- Add `navigation/recorded_track_navigation.py`: `RecordedTrackNavigation(WaypointNavigation)` — `generate_path`, `approach_start`, a one-time GNSS-sufficiency check in `prepare`, and `settings_ui` with the recording controls
- Add `interface/components/track_recorder_dialog.py`: `TrackRecorderDialog` + `RecordedTrackList` and the `TRACK_COLOR_*` constants, decoupled from `System`; `robot_marker_icon_url` makes the map marker configurable (defaults to Leaflet's marker)
- Export new symbols from `navigation/__init__.py` and `interface/components/__init__.py`; the navigation imports the dialog lazily to avoid an import cycle
- Add a navigation dropdown to `main.py` so the demo can switch to recorded-track navigation and show its controls
- Extend `tests/conftest.py` `TestSystem` and port unit + path/approach tests in `tests/test_recorded_track.py`

Purely additive — no breaking changes. Follow-up: the feldfreund app PR bumps its devkit pin to this merge commit and removes the moved code.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] I documented breaking changes and set the 'breaking change' label if needed
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Tested on an existing feldfreund_devkit implementation that did not previously include this feature.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

---
⬛ claude-opus-4-8[1m]
