### PR TITLE
Make state_at public and add pose_at helper

### DIFF
--- a/feldfreund_devkit/robot_locator.py
+++ b/feldfreund_devkit/robot_locator.py
@@ -21,7 +21,7 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
     R_IMU_ANGULAR = 0.01
     ODOMETRY_ANGULAR_WEIGHT = 0.1
     POSE_HISTORY_DURATION = 2.0
-    """Seconds of past pose estimates kept for time-based lookups via :meth:`_state_at`."""
+    """Seconds of past pose estimates kept for time-based lookups via :meth:`state_at`."""
     VELOCITY_SMOOTHING_DURATION = 0.2
     """Window over which the filtered pose is differenced into the emitted ``VELOCITY_MEASURED`` velocity."""
     VELOCITY_GAP_THRESHOLD = 0.5
@@ -97,7 +97,15 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
     def uncertainty(self) -> tuple[float, float, float]:
         return self._Sxx[0, 0], self._Sxx[1, 1], self._Sxx[2, 2]
 
-    def _state_at(self, time: float) -> tuple[Pose, np.ndarray]:
+    def pose_at(self, time: float) -> Pose:
+        """Return the estimated pose at the given ``time``, interpolated from the history.
+
+        Convenience wrapper around :meth:`state_at` for callers that only need the pose (e.g. to
+        project a time-stamped camera detection into the world at its capture time).
+        """
+        return self.state_at(time)[0]
+
+    def state_at(self, time: float) -> tuple[Pose, np.ndarray]:
         """Return the estimated pose and covariance at the given ``time``, interpolated from the history.
 
         Useful to project time-stamped measurements (e.g. camera detections) or to re-apply a latent
@@ -274,7 +282,7 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
         # in ``measurement.age`` (fix epoch - now); ``now + age`` recovers the fix epoch on both
         # hardware and simulation and adapts to each system's (variable) latency without a constant.
         fix_time = rosys.time() + gnss_measurement.age
-        reference, _ = self._state_at(fix_time)
+        reference, _ = self.state_at(fix_time)
         yaw_measurement = reference.yaw + rosys.helpers.angle(reference.yaw, pose.yaw)
         z = [[pose.x], [pose.y], [yaw_measurement]]
         h = [[reference.x], [reference.y], [reference.yaw]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 requires-python = ">=3.11, <3.14"
 dependencies = [
     "nicegui (>= 3.13.0, <4.0.0)",
-    "rosys @ git+https://github.com/zauberzeug/rosys.git@340e7b79dd0105b5b92e2978fbe9b1a8108b4f1f",
+    "rosys @ git+https://github.com/zauberzeug/rosys.git@74e36b1dba5a529ac597600016a4e55c94057efb",
     "httpx >=0.25.0",
     "coloredlogs",
     "httpcore",

--- a/tests/test_robot_locator.py
+++ b/tests/test_robot_locator.py
@@ -145,15 +145,30 @@ async def test_reset_snaps_pose_to_gnss(devkit_system):
     assert s.robot_locator.pose.y == pytest.approx(s.feldfreund.wheels.pose.y, abs=0.05)
 
 
+async def test_pose_at_returns_state_at_pose(devkit_system):
+    """``pose_at`` is the pose-only convenience wrapper around ``state_at``."""
+    s = devkit_system
+    s.robot_locator._ignore_gnss = True
+    await s.driver.wheels.drive(0.2, 0.0)
+    await forward(1.5)
+    requested = rosys.time() - 0.5
+    pose = s.robot_locator.pose_at(requested)
+    expected, _ = s.robot_locator.state_at(requested)
+    assert pose.x == pytest.approx(expected.x)
+    assert pose.y == pytest.approx(expected.y)
+    assert pose.yaw == pytest.approx(expected.yaw)
+    assert pose.time == requested
+
+
 async def test_state_at_interpolates_past_pose(devkit_system):
-    """``_state_at`` must return the pose estimated at an earlier time, not the live pose."""
+    """``state_at`` must return the pose estimated at an earlier time, not the live pose."""
     s = devkit_system
     s.robot_locator._ignore_gnss = True
     await s.driver.wheels.drive(0.2, 0.0)
     await forward(1.5)
     now = rosys.time()
     current_x = s.robot_locator.pose.x
-    past, _ = s.robot_locator._state_at(now - 1.0)
+    past, _ = s.robot_locator.state_at(now - 1.0)
     assert past.x < current_x  # the earlier estimate is behind the current one
     assert past.x == pytest.approx(current_x - 0.2 * 1.0, abs=0.05)  # ~0.2 m/s over 1 s
     assert past.y == pytest.approx(0.0, abs=0.02)
@@ -165,7 +180,7 @@ async def test_state_at_clamps_to_current_for_future(devkit_system):
     s.robot_locator._ignore_gnss = True
     await s.driver.wheels.drive(0.2, 0.0)
     await forward(1.0)
-    future, _ = s.robot_locator._state_at(rosys.time() + 10.0)
+    future, _ = s.robot_locator.state_at(rosys.time() + 10.0)
     assert future.x == pytest.approx(s.robot_locator.pose.x)
     assert future.yaw == pytest.approx(s.robot_locator.pose.yaw)
 
@@ -190,7 +205,7 @@ async def test_state_at_interpolates_yaw_across_turn(devkit_system):
     await forward(1.5)
     now = rosys.time()
     current_yaw = s.robot_locator.pose.yaw
-    past, _ = s.robot_locator._state_at(now - 1.0)
+    past, _ = s.robot_locator.state_at(now - 1.0)
     assert abs(past.yaw) < abs(current_yaw)  # earlier in the turn ⇒ smaller angle
 
 
@@ -213,7 +228,7 @@ async def test_state_at_with_empty_history_returns_live_pose(devkit_system):
     await forward(1.0)
     s.robot_locator._pose_history.clear()
     requested = rosys.time() - 0.5
-    pose, covariance = s.robot_locator._state_at(requested)
+    pose, covariance = s.robot_locator.state_at(requested)
     assert pose.x == pytest.approx(s.robot_locator.pose.x)
     assert pose.y == pytest.approx(s.robot_locator.pose.y)
     assert pose.yaw == pytest.approx(s.robot_locator.pose.yaw)
@@ -229,7 +244,7 @@ async def test_state_at_does_not_alias_live_state(devkit_system):
     await forward(1.0)
     live_x_before = s.robot_locator.pose.x
     buffered_covariance_before = s.robot_locator._pose_history[-1][2].copy()
-    pose, covariance = s.robot_locator._state_at(rosys.time() + 10.0)  # future clamp → newest estimate
+    pose, covariance = s.robot_locator.state_at(rosys.time() + 10.0)  # future clamp → newest estimate
     assert pose is not s.robot_locator.pose
     pose.x += 100.0
     covariance += 100.0
@@ -245,7 +260,7 @@ async def test_state_at_matches_exact_history_timestamp(devkit_system):
     await forward(1.5)
     middle_time, middle_state, middle_covariance = \
         list(s.robot_locator._pose_history)[len(s.robot_locator._pose_history) // 2]
-    pose, covariance = s.robot_locator._state_at(middle_time)
+    pose, covariance = s.robot_locator.state_at(middle_time)
     assert pose.x == pytest.approx(middle_state[0, 0])
     assert pose.y == pytest.approx(middle_state[1, 0])
     assert pose.yaw == pytest.approx(middle_state[2, 0])
@@ -260,8 +275,8 @@ async def test_state_at_returns_growing_covariance(devkit_system):
     await s.driver.wheels.drive(0.2, 0.0)
     await forward(1.5)
     now = rosys.time()
-    _, past_covariance = s.robot_locator._state_at(now - 1.0)
-    _, recent_covariance = s.robot_locator._state_at(now)
+    _, past_covariance = s.robot_locator.state_at(now - 1.0)
+    _, recent_covariance = s.robot_locator.state_at(now)
     assert past_covariance.shape == (3, 3)
     assert recent_covariance[0, 0] >= past_covariance[0, 0]  # uncertainty grows without corrections
 

--- a/uv.lock
+++ b/uv.lock
@@ -681,7 +681,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "nicegui", specifier = ">=3.13.0,<4.0.0" },
     { name = "psutil" },
-    { name = "rosys", git = "https://github.com/zauberzeug/rosys.git?rev=340e7b79dd0105b5b92e2978fbe9b1a8108b4f1f" },
+    { name = "rosys", git = "https://github.com/zauberzeug/rosys.git?rev=74e36b1dba5a529ac597600016a4e55c94057efb" },
 ]
 
 [package.metadata.requires-dev]
@@ -2639,11 +2639,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.29"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]
@@ -2806,8 +2806,8 @@ wheels = [
 
 [[package]]
 name = "rosys"
-version = "0.33.0.post11.dev0+340e7b79"
-source = { git = "https://github.com/zauberzeug/rosys.git?rev=340e7b79dd0105b5b92e2978fbe9b1a8108b4f1f#340e7b79dd0105b5b92e2978fbe9b1a8108b4f1f" }
+version = "0.33.0.post16.dev0+74e36b1d"
+source = { git = "https://github.com/zauberzeug/rosys.git?rev=74e36b1dba5a529ac597600016a4e55c94057efb#74e36b1dba5a529ac597600016a4e55c94057efb" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cairosvg" },


### PR DESCRIPTION
### Motivation

Plant locators need the robot pose *at a detection's capture time*, not the live pose. The interpolated lookup already exists in `RobotLocator` but was private.

### Implementation

- Rename `_state_at` → `state_at` (pose + covariance).
- Add `pose_at(time)` convenience wrapper returning just the interpolated pose.
- Bump the `rosys` pin.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] I documented breaking changes and set the 'breaking change' label if needed
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
