### PR TITLE
Remove dead prepared-state guard from WaypointNavigation

### DIFF
--- a/feldfreund_devkit/navigation/waypoint_navigation.py
+++ b/feldfreund_devkit/navigation/waypoint_navigation.py
@@ -30,7 +30,6 @@ class WaypointNavigation(rosys.persistence.Persistable):
         self._default_min_speed = driver.parameters.throttle_at_end_min_speed
         self._default_max_speed = driver.parameters.linear_speed_limit
         self._upcoming_path: list[DriveSegment] = []
-        self._is_prepared = False
         self.linear_speed_limit = self.LINEAR_SPEED_LIMIT
 
         self.PATH_GENERATED = Event[list[DriveSegment]]()
@@ -62,17 +61,11 @@ class WaypointNavigation(rosys.persistence.Persistable):
         """Returns True as long as there are waypoints to drive to."""
         return self.current_segment is not None
 
-    @property
-    def is_prepared(self) -> bool:
-        """Returns True if the navigation has been prepared for the start of the automation."""
-        return self._is_prepared
-
     @track
     async def prepare(self) -> bool:
         """Prepares the navigation for the start of the automation
 
         Returns true if all preparations were successful, otherwise false."""
-        self._is_prepared = True
         self._upcoming_path = self.generate_path()
         if not self._upcoming_path:
             self.log.error('Path generation failed')
@@ -139,13 +132,10 @@ class WaypointNavigation(rosys.persistence.Persistable):
     @track
     async def finish(self) -> None:
         """Executed after the navigation is done"""
-        if not self._is_prepared:
-            return
-        self._is_prepared = False
-        self.log.debug('Navigation finished')
         await self.driver.wheels.stop()
         await self.implement.deactivate()
         gc.collect()  # NOTE: auto garbage collection is deactivated to avoid hiccups from Global Interpreter Lock (GIL) so we collect here to reduce memory pressure
+        self.log.debug('Navigation finished')
 
     @track
     async def _drive_along_segment(self, *, linear_speed_limit: float = 0.3) -> None:


### PR DESCRIPTION
### Motivation

The `is_prepared` property had no callers, and the `_is_prepared` flag it exposed was a dead reentrancy guard: `finish()` is only ever invoked once, from the `finally` block of `start()`, so the `if not self._is_prepared: return` check never fired. It also failed to guard against preparation failures, since `prepare()` set the flag before doing any work. Removing the dead state.

### Implementation

- Remove the `is_prepared` property and the `_is_prepared` flag (set in `prepare()`, checked/reset in `finish()`)
- `finish()` now always runs its cleanup (`wheels.stop()`, `implement.deactivate()`, `gc.collect()`); these are idempotent, so dropping the guard is safe in all call paths
- Move the `'Navigation finished'` debug log to after cleanup completes

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] I documented breaking changes and set the 'breaking change' label if needed
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
