### PR TITLE
Set recorder robot-marker icon only once

### DIFF
--- a/feldfreund_devkit/interface/components/track_recorder_dialog.py
+++ b/feldfreund_devkit/interface/components/track_recorder_dialog.py
@@ -388,10 +388,13 @@ class TrackRecorderDialog:
     def update_robot_position(self) -> None:
         geo_pose = GeoPose.from_pose(self.pose_provider.pose)
         latlng = geo_pose.point.degree_tuple
-        self.robot_marker = self.robot_marker or self.dialog_map.marker(latlng=latlng)
-        if self.robot_marker_icon_url is not None:
-            icon = f'L.icon({{iconUrl: "{self.robot_marker_icon_url}", iconSize: [50,50], iconAnchor: [20,20]}})'
-            self.robot_marker.run_method(':setIcon', icon)
+        if self.robot_marker is None:
+            # Set the icon only once on creation; it never changes, so re-applying
+            # it on every 1-second tick would be needless client traffic.
+            self.robot_marker = self.dialog_map.marker(latlng=latlng)
+            if self.robot_marker_icon_url is not None:
+                icon = f'L.icon({{iconUrl: "{self.robot_marker_icon_url}", iconSize: [50,50], iconAnchor: [20,20]}})'
+                self.robot_marker.run_method(':setIcon', icon)
         self.robot_marker.move(*latlng)
 
     def _on_key(self, e) -> None:

--- a/feldfreund_devkit/interface/components/track_recorder_dialog.py
+++ b/feldfreund_devkit/interface/components/track_recorder_dialog.py
@@ -389,8 +389,6 @@ class TrackRecorderDialog:
         geo_pose = GeoPose.from_pose(self.pose_provider.pose)
         latlng = geo_pose.point.degree_tuple
         if self.robot_marker is None:
-            # Set the icon only once on creation; it never changes, so re-applying
-            # it on every 1-second tick would be needless client traffic.
             self.robot_marker = self.dialog_map.marker(latlng=latlng)
             if self.robot_marker_icon_url is not None:
                 icon = f'L.icon({{iconUrl: "{self.robot_marker_icon_url}", iconSize: [50,50], iconAnchor: [20,20]}})'


### PR DESCRIPTION
### Motivation

The recorder dialog re-applied the robot marker's (constant) icon on every 1-second timer tick via `run_method(':setIcon', ...)`, producing needless client traffic.

### Implementation

- In `TrackRecorderDialog.update_robot_position`, set the icon only when `robot_marker` is first created; subsequent ticks only `move()` the existing marker.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

---
⬛ claude-opus-4-8 (1M context)
