### PR TITLE
Cover the PPS GPS quality in the GNSS-requirement test

### DIFF
--- a/tests/test_recorded_track.py
+++ b/tests/test_recorded_track.py
@@ -110,12 +110,14 @@ def test_meets_gnss_requirement():
     assert track.meets_gnss_requirement(GpsQuality.INVALID) is False
     assert track.meets_gnss_requirement(GpsQuality.GPS) is False
     assert track.meets_gnss_requirement(GpsQuality.DGPS) is True
+    assert track.meets_gnss_requirement(GpsQuality.PPS) is True
     assert track.meets_gnss_requirement(GpsQuality.RTK_FIXED) is True
     assert track.meets_gnss_requirement(GpsQuality.RTK_FLOAT) is True
 
     track.gnss_requirement = GnssRequirement.RTK
     assert track.meets_gnss_requirement(None) is False
     assert track.meets_gnss_requirement(GpsQuality.DGPS) is False
+    assert track.meets_gnss_requirement(GpsQuality.PPS) is False
     assert track.meets_gnss_requirement(GpsQuality.RTK_FLOAT) is False
     assert track.meets_gnss_requirement(GpsQuality.RTK_FIXED) is True
 


### PR DESCRIPTION
### Motivation

`GnssRequirement.GNSS` accepts `GpsQuality.PPS` as sufficient, but `test_meets_gnss_requirement` never exercised the `PPS` case, leaving that branch untested.

### Implementation

- Add `meets_gnss_requirement(GpsQuality.PPS) is True` under the `GNSS` requirement.
- Add `meets_gnss_requirement(GpsQuality.PPS) is False` under the stricter `RTK` requirement to fully pin down PPS handling.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

---
⬛ claude-opus-4-8 (1M context)
