### PR TITLE
Stop the recorder dialog from leaking map, timer and keyboard handler on every open

### DIFF
--- a/feldfreund_devkit/interface/components/track_recorder_dialog.py
+++ b/feldfreund_devkit/interface/components/track_recorder_dialog.py
@@ -255,6 +255,8 @@ class TrackRecorderDialog:
 
         self._track_segments: list[GenericLayer] = []
         self._waypoint_markers: list[GenericLayer] = []
+        self._tick_timer: ui.timer | None = None
+        self._torn_down = False
 
         self._build_dialog()
         self._update_track_on_map()
@@ -265,7 +267,7 @@ class TrackRecorderDialog:
         self.controller.WAYPOINT_ADDED.subscribe(self._on_waypoint_added)
         self.controller.RECORDING_STARTED.subscribe(self._on_recording_started)
         self.controller.RECORDING_STOPPED.subscribe(self._on_recording_stopped)
-        self.dialog.on('hide', self._unsubscribe)
+        self.dialog.on('hide', self.tear_down)
 
     @property
     def is_recording(self) -> bool:
@@ -279,6 +281,21 @@ class TrackRecorderDialog:
         self.controller.WAYPOINT_ADDED.unsubscribe(self._on_waypoint_added)
         self.controller.RECORDING_STARTED.unsubscribe(self._on_recording_started)
         self.controller.RECORDING_STOPPED.unsubscribe(self._on_recording_stopped)
+
+    def tear_down(self) -> None:
+        """Release everything that would otherwise outlive this dialog.
+
+        The recorder is rebuilt on every open, so a closed or replaced instance
+        must drop its controller subscriptions and stop its 1-second timer; the
+        DOM (dialog, map, keyboard handler) is removed by the owner clearing the
+        dialog host. Idempotent: both the ``hide`` event and the owner may call it.
+        """
+        if self._torn_down:
+            return
+        self._torn_down = True
+        self._unsubscribe()
+        if self._tick_timer is not None:
+            self._tick_timer.cancel()
 
     def _build_dialog(self) -> None:
         with ui.dialog() as self.dialog, \
@@ -326,7 +343,7 @@ class TrackRecorderDialog:
             },
         )
         self.update_robot_position()
-        ui.timer(1, self._tick)
+        self._tick_timer = ui.timer(1, self._tick)
 
     def _build_action_bar(self) -> None:
         with ui.row().classes('w-full items-center gap-3 px-1'):

--- a/feldfreund_devkit/interface/components/track_recorder_dialog.py
+++ b/feldfreund_devkit/interface/components/track_recorder_dialog.py
@@ -256,7 +256,6 @@ class TrackRecorderDialog:
         self._track_segments: list[GenericLayer] = []
         self._waypoint_markers: list[GenericLayer] = []
         self._tick_timer: ui.timer | None = None
-        self._torn_down = False
 
         self._build_dialog()
         self._update_track_on_map()
@@ -283,16 +282,13 @@ class TrackRecorderDialog:
         self.controller.RECORDING_STOPPED.unsubscribe(self._on_recording_stopped)
 
     def tear_down(self) -> None:
-        """Release everything that would otherwise outlive this dialog.
+        """Drop controller subscriptions and stop the tick timer.
 
-        The recorder is rebuilt on every open, so a closed or replaced instance
-        must drop its controller subscriptions and stop its 1-second timer; the
-        DOM (dialog, map, keyboard handler) is removed by the owner clearing the
-        dialog host. Idempotent: both the ``hide`` event and the owner may call it.
+        The DOM (dialog, map, keyboard) is removed by the owner clearing the dialog
+        host; ``ui.timer`` even cancels itself on deletion, but ``hide`` does not
+        delete anything, so the timer is cancelled explicitly here. Idempotent —
+        both ``unsubscribe`` and ``Timer.cancel`` are no-ops once already done.
         """
-        if self._torn_down:
-            return
-        self._torn_down = True
         self._unsubscribe()
         if self._tick_timer is not None:
             self._tick_timer.cancel()

--- a/feldfreund_devkit/navigation/recorded_track_navigation.py
+++ b/feldfreund_devkit/navigation/recorded_track_navigation.py
@@ -225,6 +225,14 @@ class RecordedTrackNavigation(WaypointNavigation):
         # ``interface.components`` which imports back into this package.
         # pylint: disable=import-outside-toplevel
         from ..interface.components.track_recorder_dialog import TrackRecorderDialog  # noqa: PLC0415
+        # Tear down any previous recorder and empty the host before rebuilding, so each
+        # open starts fresh instead of leaking the prior dialog's map, 1-second timer
+        # and keyboard handler into the (deliberately stable) host.
+        if self._current_recorder is not None:
+            self._current_recorder.tear_down()
+            self._current_recorder = None
+        if self._dialog_host is not None:
+            self._dialog_host.clear()
         # Build inside the stable dialog host so settings refreshes don't tear the dialog down.
         host = self._dialog_host if self._dialog_host is not None else contextlib.nullcontext()
         with host:

--- a/tests/test_recorder_dialog.py
+++ b/tests/test_recorder_dialog.py
@@ -1,0 +1,43 @@
+# pylint: disable=protected-access
+from nicegui import Client
+from nicegui.page import page
+
+from feldfreund_devkit.navigation.recorded_track import RecordedTrack
+
+
+def _open(devkit_system):
+    """Open the recorder for a fresh track and return the live dialog."""
+    devkit_system.recorded_track_navigation._open_recorder(RecordedTrack())
+    return devkit_system.recorded_track_navigation._current_recorder
+
+
+async def test_reopening_recorder_releases_the_previous_one(devkit_system):
+    """Each open must tear the previous recorder down instead of leaking its
+    controller subscriptions and 1-second tick timer into a long-lived session."""
+    controller = devkit_system.track_recording_controller
+
+    with Client(page('/')):  # standalone slot to build the dialog into (no running server)
+        previous = _open(devkit_system)
+        assert not previous._tick_timer._is_canceled
+        waypoint_subscribers = len(controller.WAYPOINT_ADDED.callbacks)
+
+        current = _open(devkit_system)
+        assert current is not previous
+        # the previous recorder is fully released ...
+        assert previous._tick_timer._is_canceled
+        assert not any(c.func == previous._on_waypoint_added for c in controller.WAYPOINT_ADDED.callbacks)
+        # ... and the replacement does not accumulate subscriptions on top of it.
+        assert len(controller.WAYPOINT_ADDED.callbacks) == waypoint_subscribers
+
+
+async def test_tear_down_is_idempotent(devkit_system):
+    """``hide`` and the owner may both tear a recorder down; doing so twice is a no-op."""
+    controller = devkit_system.track_recording_controller
+
+    with Client(page('/')):
+        recorder = _open(devkit_system)
+        recorder.tear_down()
+        recorder.tear_down()
+
+        assert recorder._tick_timer._is_canceled
+        assert not any(c.func == recorder._on_waypoint_added for c in controller.WAYPOINT_ADDED.callbacks)


### PR DESCRIPTION
### Motivation

Opening the track recorder (`start_track_editing` / `open_recorder`, triggerable arbitrarily often) leaked resources: `_open_recorder` built a new `TrackRecorderDialog` into the deliberately stable `_dialog_host` without ever clearing it, and closing only ran `_unsubscribe`. Each open left behind a running `ui.timer(1, self._tick)` (ticking `update_robot_position` on a hidden Leaflet map), the map itself and a `ui.keyboard` handler, accumulating over a long session.

### Implementation

- Add `TrackRecorderDialog.tear_down()`: idempotent; unsubscribes from controller events and cancels the 1-second tick timer (now stored in `self._tick_timer`). Bind it to the dialog `hide` event in place of `_unsubscribe`.
- In `_open_recorder`, tear down the previous recorder and `clear()` the dialog host before building a new one, so the stale dialog/map/keyboard DOM is removed instead of accumulating.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

---
⬛ claude-opus-4-8 (1M context)
