### PR TITLE
Derive heading from the position track when GNSS provides no heading

### DIFF
--- a/feldfreund_devkit/robot_locator.py
+++ b/feldfreund_devkit/robot_locator.py
@@ -29,12 +29,12 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
     recorded) is treated as a discontinuity the velocity is not differenced across. Kept separate from
     ``VELOCITY_SMOOTHING_DURATION`` so tuning the smoothing window can't make a normal sample interval look
     like a gap; must stay comfortably above the odometry sample interval (else every step reads as a gap)."""
-    SINGLE_ANTENNA_MIN_COURSE_DISTANCE = 0.05
-    """Single-antenna mode only derives a course heading once the robot has moved at least this far (m)
-    between two GNSS fixes; below it the angle between two noisy positions is dominated by position noise."""
-    SINGLE_ANTENNA_MIN_COURSE_STD = np.deg2rad(1.0)
-    """Floor for the course-heading uncertainty in single-antenna mode, so a long travel distance can't
-    make the position-derived heading look more certain than the underlying GNSS position noise warrants."""
+    COURSE_MIN_DISTANCE = 0.05
+    """A course heading is only derived from the position track once the robot has moved at least this far
+    (m) between two GNSS fixes; below it the angle between two noisy positions is dominated by position noise."""
+    COURSE_MIN_STD = np.deg2rad(1.0)
+    """Floor for the position-derived course-heading uncertainty, so a long travel distance can't make it
+    look more certain than the underlying GNSS position noise warrants."""
 
     def __init__(self,
                  wheels: Wheels, *,
@@ -74,11 +74,7 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
 
         self._ignore_gnss = gnss is None
         self._ignore_imu = imu is None
-        # Single-antenna mode: ignore the GNSS heading entirely and reconstruct it from the position
-        # track instead (for running the robot with one antenna). Off by default — the dual-antenna RTK
-        # heading path is unchanged. See AG-204.
-        self._single_antenna_mode = False
-        # Last GNSS position (local x, y) used to derive a course heading in single-antenna mode.
+        # Last GNSS position (local x, y), used to derive a course heading when a fix carries no heading.
         self._last_gnss_local_position: tuple[float, float] | None = None
         self._auto_tilt_correction = True
         self._r_odom_linear = self.R_ODOM_LINEAR
@@ -279,12 +275,10 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
         """Triggers the 'update' step of the Kalman filter."""
         if self._ignore_gnss:
             return
-        if self._single_antenna_mode:
-            self._handle_single_antenna_gnss(gnss_measurement)
-            return
         if not np.isfinite(gnss_measurement.heading_std_dev):
-            # normally we would only handle the position if no heading is available,
-            # but the Feldfreund needs the rtk accuracy to function properly
+            # No GNSS heading (e.g. a single-antenna receiver): fuse the position and reconstruct the
+            # heading from the position track instead of dropping the fix.
+            self._handle_gnss_without_heading(gnss_measurement)
             return
         pose, r_xy, r_theta = self._get_local_pose_and_uncertainty(gnss_measurement)
         if self._auto_tilt_correction and isinstance(self._imu, Imu) and not self._ignore_imu and self._imu.last_measurement is not None:
@@ -306,13 +300,13 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
         Q = np.diag(variance)
         self._update(z=np.array(z), h=np.array(h), H=H, Q=Q)
 
-    def _handle_single_antenna_gnss(self, gnss_measurement: GnssMeasurement) -> None:
-        """Fuse a single-antenna GNSS fix: position only, with heading derived from the position track.
+    def _handle_gnss_without_heading(self, gnss_measurement: GnssMeasurement) -> None:
+        """Fuse a GNSS fix that carries no heading: position only, heading derived from the position track.
 
-        A single-antenna receiver provides no heading, so unlike the dual-antenna path the GNSS yaw is
-        never fused. Position (x, y) is fused on its own, and a course-over-ground heading is reconstructed
-        from the displacement between consecutive fixes (see :meth:`_fuse_course_heading`). The GNSS
-        position carries no latency-free yaw, so heading lives purely in the motion model plus that course.
+        A fix without a heading (e.g. from a single-antenna receiver) used to be dropped entirely. Instead
+        we fuse the position (x, y) on its own and reconstruct a course-over-ground heading from the
+        displacement between consecutive fixes (see :meth:`_fuse_course_heading`), so the heading lives in
+        the motion model plus that course rather than the missing GNSS yaw.
         """
         # use the point (not the full pose) so we never touch the GNSS heading, which is absent here
         local_point = gnss_measurement.pose.point.to_local()
@@ -333,9 +327,9 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
         self._fuse_course_heading(local_point.x, local_point.y, r_xy)
 
     def _fuse_course_heading(self, x: float, y: float, r_xy: float) -> None:
-        """Fuse a heading derived from the displacement between consecutive single-antenna GNSS fixes.
+        """Fuse a heading derived from the displacement between consecutive headingless GNSS fixes.
 
-        The course is meaningful only once the robot has actually moved (:attr:`SINGLE_ANTENNA_MIN_COURSE_DISTANCE`);
+        The course is meaningful only once the robot has actually moved (:attr:`COURSE_MIN_DISTANCE`);
         below that the angle between two noisy positions is dominated by noise and is skipped. GNSS alone
         cannot tell forward from reverse travel, so the sign is taken from the filtered velocity. The course
         uncertainty grows as the travel distance shrinks (``~sqrt(2)*r_xy/distance``), floored so it never
@@ -347,12 +341,12 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
             return
         dx, dy = x - previous[0], y - previous[1]
         distance = float(np.hypot(dx, dy))
-        if distance < self.SINGLE_ANTENNA_MIN_COURSE_DISTANCE:
+        if distance < self.COURSE_MIN_DISTANCE:
             return
         course = float(np.arctan2(dy, dx))
         if self._velocity.linear < 0:
             course += np.pi  # GNSS can't distinguish forward from reverse travel; trust the odometry sign
-        r_course = max(np.sqrt(2.0) * r_xy / distance, self.SINGLE_ANTENNA_MIN_COURSE_STD)
+        r_course = max(np.sqrt(2.0) * r_xy / distance, self.COURSE_MIN_STD)
         yaw_measurement = self._x[2, 0] + rosys.helpers.angle(self._x[2, 0], course)
         self._update(z=np.array([[yaw_measurement]]),
                      h=np.array([[self._x[2, 0]]]),
@@ -474,8 +468,6 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
                     .bind_value_to(self, '_ignore_gnss').tooltip('Ignore GNSS measurements. When deactivated, reset the filter for better positioning.')
                 ui.checkbox('Ignore IMU', value=self._ignore_imu).props('dense color=red').classes('col-span-2') \
                     .bind_value_to(self, '_ignore_imu')
-                ui.checkbox('Single antenna', value=self._single_antenna_mode).props('dense').classes('col-span-2') \
-                    .bind_value_to(self, '_single_antenna_mode').tooltip('Ignore the GNSS heading and derive it from the position track (one-antenna mode).')
                 ui.checkbox('Correct GNSS with IMU', value=self._auto_tilt_correction).props('dense').classes('col-span-2') \
                     .bind_value_to(self, '_auto_tilt_correction')
                 with ui.column().classes('w-24 gap-0'):

--- a/feldfreund_devkit/robot_locator.py
+++ b/feldfreund_devkit/robot_locator.py
@@ -29,6 +29,12 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
     recorded) is treated as a discontinuity the velocity is not differenced across. Kept separate from
     ``VELOCITY_SMOOTHING_DURATION`` so tuning the smoothing window can't make a normal sample interval look
     like a gap; must stay comfortably above the odometry sample interval (else every step reads as a gap)."""
+    SINGLE_ANTENNA_MIN_COURSE_DISTANCE = 0.05
+    """Single-antenna mode only derives a course heading once the robot has moved at least this far (m)
+    between two GNSS fixes; below it the angle between two noisy positions is dominated by position noise."""
+    SINGLE_ANTENNA_MIN_COURSE_STD = np.deg2rad(1.0)
+    """Floor for the course-heading uncertainty in single-antenna mode, so a long travel distance can't
+    make the position-derived heading look more certain than the underlying GNSS position noise warrants."""
 
     def __init__(self,
                  wheels: Wheels, *,
@@ -68,6 +74,12 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
 
         self._ignore_gnss = gnss is None
         self._ignore_imu = imu is None
+        # Single-antenna mode: ignore the GNSS heading entirely and reconstruct it from the position
+        # track instead (for running the robot with one antenna). Off by default — the dual-antenna RTK
+        # heading path is unchanged. See AG-204.
+        self._single_antenna_mode = False
+        # Last GNSS position (local x, y) used to derive a course heading in single-antenna mode.
+        self._last_gnss_local_position: tuple[float, float] | None = None
         self._auto_tilt_correction = True
         self._r_odom_linear = self.R_ODOM_LINEAR
         self._r_odom_angular = self.R_ODOM_ANGULAR
@@ -267,6 +279,9 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
         """Triggers the 'update' step of the Kalman filter."""
         if self._ignore_gnss:
             return
+        if self._single_antenna_mode:
+            self._handle_single_antenna_gnss(gnss_measurement)
+            return
         if not np.isfinite(gnss_measurement.heading_std_dev):
             # normally we would only handle the position if no heading is available,
             # but the Feldfreund needs the rtk accuracy to function properly
@@ -290,6 +305,59 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
         variance = np.array([r_xy, r_xy, r_theta], dtype=np.float64)**2
         Q = np.diag(variance)
         self._update(z=np.array(z), h=np.array(h), H=H, Q=Q)
+
+    def _handle_single_antenna_gnss(self, gnss_measurement: GnssMeasurement) -> None:
+        """Fuse a single-antenna GNSS fix: position only, with heading derived from the position track.
+
+        A single-antenna receiver provides no heading, so unlike the dual-antenna path the GNSS yaw is
+        never fused. Position (x, y) is fused on its own, and a course-over-ground heading is reconstructed
+        from the displacement between consecutive fixes (see :meth:`_fuse_course_heading`). The GNSS
+        position carries no latency-free yaw, so heading lives purely in the motion model plus that course.
+        """
+        # use the point (not the full pose) so we never touch the GNSS heading, which is absent here
+        local_point = gnss_measurement.pose.point.to_local()
+        r_xy = (gnss_measurement.latitude_std_dev + gnss_measurement.longitude_std_dev) / 2
+        # carry the current yaw estimate so the optional IMU tilt correction can rotate the antenna offset
+        position = Pose(x=local_point.x, y=local_point.y, yaw=self._x[2, 0])
+        if self._auto_tilt_correction and isinstance(self._imu, Imu) and not self._ignore_imu and self._imu.last_measurement is not None:
+            position = self._correct_gnss_with_imu(position)
+        # fuse against the estimate from the fix epoch, mirroring the dual-antenna latency handling
+        fix_time = rosys.time() + gnss_measurement.age
+        reference, _ = self.state_at(fix_time)
+        z = np.array([[position.x], [position.y]])
+        h = np.array([[reference.x], [reference.y]])
+        H = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+        Q = np.diag(np.array([r_xy, r_xy], dtype=np.float64)**2)
+        self._update(z=z, h=h, H=H, Q=Q)
+        # derive heading from the raw (EKF-independent) GNSS positions, not the corrected one
+        self._fuse_course_heading(local_point.x, local_point.y, r_xy)
+
+    def _fuse_course_heading(self, x: float, y: float, r_xy: float) -> None:
+        """Fuse a heading derived from the displacement between consecutive single-antenna GNSS fixes.
+
+        The course is meaningful only once the robot has actually moved (:attr:`SINGLE_ANTENNA_MIN_COURSE_DISTANCE`);
+        below that the angle between two noisy positions is dominated by noise and is skipped. GNSS alone
+        cannot tell forward from reverse travel, so the sign is taken from the filtered velocity. The course
+        uncertainty grows as the travel distance shrinks (``~sqrt(2)*r_xy/distance``), floored so it never
+        claims more certainty than the GNSS position noise allows.
+        """
+        previous = self._last_gnss_local_position
+        self._last_gnss_local_position = (x, y)
+        if previous is None:
+            return
+        dx, dy = x - previous[0], y - previous[1]
+        distance = float(np.hypot(dx, dy))
+        if distance < self.SINGLE_ANTENNA_MIN_COURSE_DISTANCE:
+            return
+        course = float(np.arctan2(dy, dx))
+        if self._velocity.linear < 0:
+            course += np.pi  # GNSS can't distinguish forward from reverse travel; trust the odometry sign
+        r_course = max(np.sqrt(2.0) * r_xy / distance, self.SINGLE_ANTENNA_MIN_COURSE_STD)
+        yaw_measurement = self._x[2, 0] + rosys.helpers.angle(self._x[2, 0], course)
+        self._update(z=np.array([[yaw_measurement]]),
+                     h=np.array([[self._x[2, 0]]]),
+                     H=np.array([[0.0, 0.0, 1.0]]),
+                     Q=np.array([[r_course**2]]))
 
     def _get_local_pose_and_uncertainty(self, gnss_measurement: GnssMeasurement) -> tuple[Pose, float, float]:
         pose = gnss_measurement.pose.to_local()
@@ -385,6 +453,7 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
         np.fill_diagonal(self._Sxx, variance)
         self._pose_timestamp = rosys.time()
         self._pose_history.clear()  # the pose jumps discontinuously, so past estimates are invalid
+        self._last_gnss_local_position = None  # the position track is broken by the jump
         self._update_frame()
 
     def developer_ui(self) -> None:
@@ -405,6 +474,8 @@ class RobotLocator(rosys.persistence.Persistable, FrameProvider, PoseProvider, V
                     .bind_value_to(self, '_ignore_gnss').tooltip('Ignore GNSS measurements. When deactivated, reset the filter for better positioning.')
                 ui.checkbox('Ignore IMU', value=self._ignore_imu).props('dense color=red').classes('col-span-2') \
                     .bind_value_to(self, '_ignore_imu')
+                ui.checkbox('Single antenna', value=self._single_antenna_mode).props('dense').classes('col-span-2') \
+                    .bind_value_to(self, '_single_antenna_mode').tooltip('Ignore the GNSS heading and derive it from the position track (one-antenna mode).')
                 ui.checkbox('Correct GNSS with IMU', value=self._auto_tilt_correction).props('dense').classes('col-span-2') \
                     .bind_value_to(self, '_auto_tilt_correction')
                 with ui.column().classes('w-24 gap-0'):

--- a/tests/test_robot_locator.py
+++ b/tests/test_robot_locator.py
@@ -114,30 +114,13 @@ async def test_gnss_corrects_injected_error(devkit_system):
     assert s.robot_locator.pose.y == pytest.approx(0.0, abs=0.05)
 
 
-async def test_non_finite_heading_disables_update(devkit_system):
-    """If the GNSS heading uncertainty is not finite, the update is skipped entirely
-    (the Feldfreund relies on RTK heading), so an injected error must NOT be corrected
-    even while driving (which otherwise keeps the Kalman gain alive)."""
+async def test_gnss_without_heading_corrects_position(devkit_system):
+    """A fix without a heading still corrects the position (it is no longer dropped).
+
+    With no GNSS heading the position is fused on its own, so an injected position error must be
+    pulled back while driving."""
     s = devkit_system
-    await forward(2.0)
-    s.feldfreund.gnss._heading_std_dev = np.inf
-    await forward(1.0)  # flush a measurement so the guard is exercised
-    s.robot_locator._x[1, 0] = 1.0
-    s.robot_locator._update_frame()
-    await s.driver.wheels.drive(0.2, 0.0)
-    await forward(5.0)
-    await s.driver.wheels.drive(0.0, 0.0)
-    assert s.robot_locator.pose.y == pytest.approx(1.0, abs=1e-6)  # uncorrected (straight drive keeps y in odometry)
-
-
-async def test_single_antenna_corrects_position_without_heading(devkit_system):
-    """In single-antenna mode a fix without a heading still corrects the position.
-
-    The dual-antenna path skips headingless fixes entirely; single-antenna mode instead fuses the
-    position on its own, so an injected position error must be pulled back while driving."""
-    s = devkit_system
-    s.robot_locator._single_antenna_mode = True
-    s.feldfreund.gnss._heading_std_dev = np.inf  # emulate a one-antenna receiver: no heading
+    s.feldfreund.gnss._heading_std_dev = np.inf  # emulate a receiver without heading (e.g. single antenna)
     await forward(2.0)
     s.robot_locator._x[1, 0] = 1.0  # inject a 1 m error in y
     s.robot_locator._update_frame()
@@ -147,14 +130,13 @@ async def test_single_antenna_corrects_position_without_heading(devkit_system):
     assert s.robot_locator.pose.y == pytest.approx(0.0, abs=0.05)
 
 
-async def test_single_antenna_derives_heading_from_motion(devkit_system):
-    """The heading is reconstructed from the GNSS position track, not from the receiver.
+async def test_gnss_without_heading_derives_heading_from_motion(devkit_system):
+    """The heading is reconstructed from the GNSS position track when the fix carries none.
 
     With no GNSS heading, an injected yaw error cannot be corrected by a heading measurement. The
     course-over-ground computed from consecutive fixes must pull the heading back to the driven
     direction (0 rad) while moving forward."""
     s = devkit_system
-    s.robot_locator._single_antenna_mode = True
     s.feldfreund.gnss._heading_std_dev = np.inf
     await forward(2.0)
     s.robot_locator._x[2, 0] = 0.5  # inject a heading error the GNSS heading can no longer fix
@@ -165,14 +147,13 @@ async def test_single_antenna_derives_heading_from_motion(devkit_system):
     assert s.robot_locator.pose.yaw == pytest.approx(0.0, abs=0.1)
 
 
-async def test_single_antenna_heading_handles_reverse(devkit_system):
+async def test_gnss_without_heading_handles_reverse(devkit_system):
     """GNSS course points opposite to the heading when reversing; the velocity sign must flip it back.
 
     Driving backwards, the position track runs opposite to where the robot faces. Without the
     forward/backward correction the derived heading would be off by 180°, so the estimate must still
     converge to the true 0 rad heading."""
     s = devkit_system
-    s.robot_locator._single_antenna_mode = True
     s.feldfreund.gnss._heading_std_dev = np.inf
     await forward(2.0)
     s.robot_locator._x[2, 0] = 0.5

--- a/tests/test_robot_locator.py
+++ b/tests/test_robot_locator.py
@@ -130,6 +130,59 @@ async def test_non_finite_heading_disables_update(devkit_system):
     assert s.robot_locator.pose.y == pytest.approx(1.0, abs=1e-6)  # uncorrected (straight drive keeps y in odometry)
 
 
+async def test_single_antenna_corrects_position_without_heading(devkit_system):
+    """In single-antenna mode a fix without a heading still corrects the position.
+
+    The dual-antenna path skips headingless fixes entirely; single-antenna mode instead fuses the
+    position on its own, so an injected position error must be pulled back while driving."""
+    s = devkit_system
+    s.robot_locator._single_antenna_mode = True
+    s.feldfreund.gnss._heading_std_dev = np.inf  # emulate a one-antenna receiver: no heading
+    await forward(2.0)
+    s.robot_locator._x[1, 0] = 1.0  # inject a 1 m error in y
+    s.robot_locator._update_frame()
+    await s.driver.wheels.drive(0.2, 0.0)
+    await forward(6.0)
+    await s.driver.wheels.drive(0.0, 0.0)
+    assert s.robot_locator.pose.y == pytest.approx(0.0, abs=0.05)
+
+
+async def test_single_antenna_derives_heading_from_motion(devkit_system):
+    """The heading is reconstructed from the GNSS position track, not from the receiver.
+
+    With no GNSS heading, an injected yaw error cannot be corrected by a heading measurement. The
+    course-over-ground computed from consecutive fixes must pull the heading back to the driven
+    direction (0 rad) while moving forward."""
+    s = devkit_system
+    s.robot_locator._single_antenna_mode = True
+    s.feldfreund.gnss._heading_std_dev = np.inf
+    await forward(2.0)
+    s.robot_locator._x[2, 0] = 0.5  # inject a heading error the GNSS heading can no longer fix
+    s.robot_locator._update_frame()
+    await s.driver.wheels.drive(0.2, 0.0)
+    await forward(8.0)
+    await s.driver.wheels.drive(0.0, 0.0)
+    assert s.robot_locator.pose.yaw == pytest.approx(0.0, abs=0.1)
+
+
+async def test_single_antenna_heading_handles_reverse(devkit_system):
+    """GNSS course points opposite to the heading when reversing; the velocity sign must flip it back.
+
+    Driving backwards, the position track runs opposite to where the robot faces. Without the
+    forward/backward correction the derived heading would be off by 180°, so the estimate must still
+    converge to the true 0 rad heading."""
+    s = devkit_system
+    s.robot_locator._single_antenna_mode = True
+    s.feldfreund.gnss._heading_std_dev = np.inf
+    await forward(2.0)
+    s.robot_locator._x[2, 0] = 0.5
+    s.robot_locator._update_frame()
+    await s.driver.wheels.drive(-0.2, 0.0)  # reverse
+    await forward(8.0)
+    await s.driver.wheels.drive(0.0, 0.0)
+    assert s.robot_locator.pose.yaw == pytest.approx(0.0, abs=0.1)
+
+
 async def test_reset_snaps_pose_to_gnss(devkit_system):
     """Resetting must discard the current state and adopt the GNSS measurement.
 


### PR DESCRIPTION
### Motivation

A single GNSS antenna would cut cost but provides no heading, and a fix without a heading was previously dropped entirely. Instead, whenever a GNSS fix carries no heading, fuse its position and reconstruct the heading from the position track.

### Implementation

When a GNSS fix has no heading (`heading_std_dev` not finite), the `RobotLocator` EKF no longer drops it (`_handle_gnss_without_heading`):

- Fuse GNSS **position only** (2D update); the path with a real (dual-antenna RTK) heading is unchanged.
- Reconstruct a course-over-ground heading from consecutive GNSS positions (`_fuse_course_heading`) once the robot has moved at least `COURSE_MIN_DISTANCE`; the course uncertainty scales as `~sqrt(2)*r_xy/distance`, floored by `COURSE_MIN_STD`. Forward/backward is taken from the filtered velocity, since GNSS alone cannot distinguish the two.
- `_reset` clears the position track.

### Work In Progress

- First-pass exploration: the course-heading scheme and its constants are deliberately simple and want a review of the approach (and ideally a real-hardware/field check).

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [ ] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [ ] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

---
⬛ claude-opus-4-8 (1M context)
