### PR TITLE
Update rosys to newest main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 requires-python = ">=3.11, <3.14"
 dependencies = [
     "nicegui (>= 3.13.0, <4.0.0)",
-    "rosys @ git+https://github.com/zauberzeug/rosys.git@74e36b1dba5a529ac597600016a4e55c94057efb",
+    "rosys @ git+https://github.com/zauberzeug/rosys.git@1cc610ee998483c4875b4246b09f91103ad99a7a",
     "httpx >=0.25.0",
     "coloredlogs",
     "httpcore",

--- a/uv.lock
+++ b/uv.lock
@@ -681,7 +681,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "nicegui", specifier = ">=3.13.0,<4.0.0" },
     { name = "psutil" },
-    { name = "rosys", git = "https://github.com/zauberzeug/rosys.git?rev=74e36b1dba5a529ac597600016a4e55c94057efb" },
+    { name = "rosys", git = "https://github.com/zauberzeug/rosys.git?rev=1cc610ee998483c4875b4246b09f91103ad99a7a" },
 ]
 
 [package.metadata.requires-dev]
@@ -2806,8 +2806,8 @@ wheels = [
 
 [[package]]
 name = "rosys"
-version = "0.33.0.post16.dev0+74e36b1d"
-source = { git = "https://github.com/zauberzeug/rosys.git?rev=74e36b1dba5a529ac597600016a4e55c94057efb#74e36b1dba5a529ac597600016a4e55c94057efb" }
+version = "0.33.0.post19.dev0+1cc610ee"
+source = { git = "https://github.com/zauberzeug/rosys.git?rev=1cc610ee998483c4875b4246b09f91103ad99a7a#1cc610ee998483c4875b4246b09f91103ad99a7a" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cairosvg" },


### PR DESCRIPTION
### Motivation

Keep the `rosys` dependency current by updating it to the latest `main`.

### Implementation

- Bumped the `rosys` git pin in `pyproject.toml` from `74e36b1` to `1cc610e` (current `main`).
- Regenerated `uv.lock` accordingly.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] I documented breaking changes and set the 'breaking change' label if needed
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).