### PR TITLE
Load the app's .env in Secrets (configurable path + override)

### DIFF
--- a/feldfreund_devkit/config/secrets.py
+++ b/feldfreund_devkit/config/secrets.py
@@ -1,12 +1,21 @@
 import logging
 import os
+from pathlib import Path
 
 from dotenv import load_dotenv
 
 
 class Secrets:
-    def __init__(self):
-        load_dotenv()
+    def __init__(self, env_path: str | Path = '.env'):
+        """Load the app's ``.env`` into the environment, then read the required secrets from it.
+
+        :param env_path: path to the ``.env`` file, by default ``'.env'`` relative to the working directory.
+
+        An explicit path is used on purpose: a bare ``load_dotenv()`` resolves via ``find_dotenv()`` starting
+        from this devkit file, so it never reaches the consuming app's ``.env`` when the devkit is installed
+        as a (sibling) dependency. ``override=True`` lets the ``.env`` win over stale/empty pre-existing vars.
+        """
+        load_dotenv(env_path, override=True)
         self.log = logging.getLogger('devkit.secrets')
         self.TELTONIKA_PASSWORD = self._require_secret('TELTONIKA_PASSWORD')
         self.MJPEG_CAMERA_PASSWORD = self._require_secret('MJPEG_CAMERA_PASSWORD')


### PR DESCRIPTION
### Motivation

`Secrets()` used a bare `load_dotenv()`. With no path, python-dotenv resolves the `.env` via `find_dotenv()`, which walks up from the **file that calls it** — i.e. this devkit's `secrets.py`. When the devkit is installed as a (sibling/editable) dependency, that search starts in the devkit tree and never reaches the consuming app's `.env`, so the app's secrets are silently not loaded and `Secrets()` raises `Missing required environment variable`.

### Implementation

- Add an `env_path: str | Path = '.env'` parameter to `Secrets.__init__` and load it with `load_dotenv(env_path, override=True)`. An explicit path bypasses `find_dotenv()` and resolves against the CWD by default (the app's root when run from there, incl. Docker `WORKDIR /app`); apps that need a fixed location can pass their own path. `override=True` lets the `.env` win over stale/empty pre-existing env vars. This restores the behavior apps had before `Secrets` centralized the loading (`feldfreund` `main.py` used `load_dotenv('.env', override=True)`).

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary). *(not necessary — depends on process CWD/env)*
- [x] Documentation has been added (or is not necessary). *(docstring on `Secrets.__init__`)*

---
⬛ claude-opus-4-8 (1M context)
