### PR TITLE
Add MultiAP WiFi client network management to the Teltonika router

### DIFF
--- a/feldfreund_devkit/hardware/__init__.py
+++ b/feldfreund_devkit/hardware/__init__.py
@@ -3,7 +3,14 @@ from .flashlight import Flashlight, FlashlightHardware, FlashlightHardwareMosfet
 from .headlights import Headlights, HeadlightsHardware, HeadlightsSimulation
 from .safety import Safety, SafetyHardware, SafetyMixin, SafetySimulation
 from .status_control import StatusControlHardware
-from .teltonika_router import ConnectionStatus, DeviceInfo, ModemStatus, TeltonikaRouter, WifiInfo
+from .teltonika_router import (
+    ConnectionStatus,
+    DeviceInfo,
+    ModemStatus,
+    TeltonikaRouter,
+    WifiClientNetwork,
+    WifiInfo,
+)
 from .tracks import ODriveTracksHardware, TracksHardware, TracksSimulation
 
 __all__ = [
@@ -27,5 +34,6 @@ __all__ = [
     'TeltonikaRouter',
     'TracksHardware',
     'TracksSimulation',
+    'WifiClientNetwork',
     'WifiInfo',
 ]

--- a/feldfreund_devkit/hardware/teltonika_router.py
+++ b/feldfreund_devkit/hardware/teltonika_router.py
@@ -164,9 +164,12 @@ class TeltonikaRouter:
     async def refresh_wifi_client_networks(self) -> None:
         """Reload the upstream WiFi client networks from the router and emit ``WIFI_NETWORKS_CHANGED``."""
         data = await self._get(self.WIFI_INTERFACES_ENDPOINT)
+        self.log.debug('Raw %s response: %s', self.WIFI_INTERFACES_ENDPOINT, data)
         interfaces = self._normalize_interface_list(data) if data is not None else []
         self._wifi_client_networks = [self._parse_wifi_client(i) for i in interfaces
                                       if isinstance(i, dict) and i.get('mode') == 'sta']
+        self.log.info('Found %d upstream WiFi client network(s) among %d wireless interface(s)',
+                      len(self._wifi_client_networks), len(interfaces))
         self.WIFI_NETWORKS_CHANGED.emit()
 
     async def add_wifi_client_network(self, ssid: str, password: str, *,

--- a/feldfreund_devkit/hardware/teltonika_router.py
+++ b/feldfreund_devkit/hardware/teltonika_router.py
@@ -168,8 +168,10 @@ class TeltonikaRouter:
         interfaces = self._normalize_interface_list(data) if data is not None else []
         self._wifi_client_networks = [self._parse_wifi_client(i) for i in interfaces
                                       if isinstance(i, dict) and i.get('mode') == 'sta']
-        self.log.info('Found %d upstream WiFi client network(s) among %d wireless interface(s)',
-                      len(self._wifi_client_networks), len(interfaces))
+        self.log.info('Found %d upstream WiFi client network(s) among %d wireless interface(s): %s',
+                      len(self._wifi_client_networks), len(interfaces),
+                      [{'mode': i.get('mode'), 'ssid': i.get('ssid'), 'fields': sorted(i)}
+                       for i in interfaces if isinstance(i, dict)])
         self.WIFI_NETWORKS_CHANGED.emit()
 
     async def add_wifi_client_network(self, ssid: str, password: str, *,

--- a/feldfreund_devkit/hardware/teltonika_router.py
+++ b/feldfreund_devkit/hardware/teltonika_router.py
@@ -70,6 +70,7 @@ class TeltonikaRouter:
     INTERNET_CHECK_HOSTS = frozenset(('8.8.8.8', '1.1.1.1'))
     DNS_CHECK_HOSTNAMES = frozenset(('www.google.de', 'zauberzeug.com'))
     WIFI_INTERFACES_ENDPOINT = 'wireless/interfaces/config'
+    WIFI_CLIENT_MODE = 'multi_ap'  # RutOS mode of an upstream client interface (vs. 'ap' for the broadcast network)
     WIFI_ENABLE_FIELD = 'enabled'  # RutOS config field; underlying UCI toggle is the inverse 'disabled'
 
     def __init__(self, url: str, admin_password: str) -> None:
@@ -167,18 +168,37 @@ class TeltonikaRouter:
         self.log.debug('Raw %s response: %s', self.WIFI_INTERFACES_ENDPOINT, data)
         interfaces = self._normalize_interface_list(data) if data is not None else []
         self._wifi_client_networks = [self._parse_wifi_client(i) for i in interfaces
-                                      if isinstance(i, dict) and i.get('mode') == 'sta']
-        self.log.info('Found %d upstream WiFi client network(s) among %d wireless interface(s): %s',
-                      len(self._wifi_client_networks), len(interfaces),
-                      [{'mode': i.get('mode'), 'ssid': i.get('ssid'), 'fields': sorted(i)}
-                       for i in interfaces if isinstance(i, dict)])
+                                      if isinstance(i, dict) and i.get('mode') == self.WIFI_CLIENT_MODE]
+        self.log.info('Found %d upstream WiFi client network(s) among %d wireless interface(s)',
+                      len(self._wifi_client_networks), len(interfaces))
+        await self._probe_multiap_endpoints(interfaces)
         self.WIFI_NETWORKS_CHANGED.emit()
+
+    async def _probe_multiap_endpoints(self, interfaces: list[dict]) -> None:
+        """TEMPORARY: discover where the router stores the MultiAP candidate AP list.
+
+        The candidate SSIDs (each with its own enable toggle) are not the wireless interfaces;
+        this probes likely endpoints and logs their responses so the real one can be identified.
+
+        :param interfaces: the wireless interfaces already fetched, used to derive the client id.
+        """
+        multi_ap_id = next((i.get('id') for i in interfaces
+                            if isinstance(i, dict) and i.get('mode') == self.WIFI_CLIENT_MODE), None)
+        candidates = ['wireless/multi_ap/config', 'wireless/multiap/config', 'wireless/aps/config',
+                      'wireless/access_points/config', 'wireless/multi_ap_aps/config',
+                      'multiap/aps/config', 'multiap/config']
+        if multi_ap_id is not None:
+            candidates += [f'{self.WIFI_INTERFACES_ENDPOINT}/{multi_ap_id}',
+                           f'{self.WIFI_INTERFACES_ENDPOINT}/{multi_ap_id}/aps',
+                           f'{self.WIFI_INTERFACES_ENDPOINT}/{multi_ap_id}/multi_ap']
+        for endpoint in candidates:
+            self.log.info('MultiAP endpoint probe: %s -> %s', endpoint, await self._get(endpoint))
 
     async def add_wifi_client_network(self, ssid: str, password: str, *,
                                       encryption: str = 'psk2', enabled: bool = False) -> str | None:
         """Add an upstream WiFi network and return its config id, or ``None`` on failure.
 
-        The radio device and attached network are copied from an existing client entry, since
+        The radio (``wifi_id``) and attached network are copied from an existing client entry, since
         those depend on the router's wiring and cannot be guessed. Fails if none exists yet.
         Refreshes the network list on success.
 
@@ -190,16 +210,16 @@ class TeltonikaRouter:
         """
         data = await self._get(self.WIFI_INTERFACES_ENDPOINT)
         template = next((i for i in self._normalize_interface_list(data or [])
-                         if isinstance(i, dict) and i.get('mode') == 'sta'), None)
+                         if isinstance(i, dict) and i.get('mode') == self.WIFI_CLIENT_MODE), None)
         if template is None:
-            self.log.error('Cannot add WiFi client network: no existing client entry to derive device/network from')
+            self.log.error('Cannot add WiFi client network: no existing client entry to derive wifi_id/network from')
             return None
         payload = {
-            'mode': 'sta',
+            'mode': self.WIFI_CLIENT_MODE,
             'ssid': ssid,
             'key': password,
             'encryption': encryption,
-            'device': template.get('device'),
+            'wifi_id': template.get('wifi_id'),
             'network': template.get('network'),
             self.WIFI_ENABLE_FIELD: '1' if enabled else '0',
         }

--- a/feldfreund_devkit/hardware/teltonika_router.py
+++ b/feldfreund_devkit/hardware/teltonika_router.py
@@ -170,15 +170,15 @@ class TeltonikaRouter:
         self.log.info('Found %d MultiAP candidate network(s)', len(self._wifi_client_networks))
         self.WIFI_NETWORKS_CHANGED.emit()
 
-    async def add_wifi_client_network(self, ssid: str, password: str, *, enabled: bool = False) -> str | None:
-        """Add a MultiAP candidate network and return its config id, or ``None`` on failure.
+    async def add_wifi_client_network(self, ssid: str, password: str, *, enabled: bool = False) -> bool:
+        """Add a MultiAP candidate network, appended with the next free priority.
 
-        The new entry is appended with the next free priority. Refreshes the list on success.
+        Refreshes the list on success.
 
         :param ssid: the network name to join.
         :param password: the pre-shared key.
         :param enabled: whether the entry is active right after creation (default ``False``).
-        :return: the created config id, or ``None`` if creation failed.
+        :return: ``True`` if the router accepted the new network, ``False`` on failure.
         """
         priorities = [n.priority for n in self._wifi_client_networks if n.priority is not None]
         payload = {
@@ -187,15 +187,12 @@ class TeltonikaRouter:
             'priority': str(max(priorities, default=0) + 1),
             self.WIFI_ENABLE_FIELD: '1' if enabled else '0',
         }
-        response = await self._request('POST', self.MULTI_AP_ENDPOINT, json={'data': payload})
-        if response is None:
+        if await self._request('POST', self.MULTI_AP_ENDPOINT, json={'data': payload}) is None:
             self.log.error('Failed to add MultiAP candidate network %s', ssid)
-            return None
-        created = response.json().get('data')
-        network_id = created.get('id') if isinstance(created, dict) else None
-        self.log.info('Added MultiAP candidate network %s (id=%s)', ssid, network_id)
+            return False
+        self.log.info('Added MultiAP candidate network %s', ssid)
         await self.refresh_wifi_client_networks()
-        return network_id
+        return True
 
     async def remove_wifi_client_network(self, network_id: str) -> bool:
         """Delete a MultiAP candidate network by its config id, refreshing the list on success."""
@@ -213,10 +210,8 @@ class TeltonikaRouter:
         if response is None:
             self.log.error('Failed to %s MultiAP candidate network %s', 'enable' if enabled else 'disable', network_id)
             return False
-        self.log.info('PUT %s/%s -> %s', self.MULTI_AP_ENDPOINT, network_id, response.json())  # TEMPORARY diagnostic
+        self.log.info('%s MultiAP candidate network %s', 'Enabled' if enabled else 'Disabled', network_id)
         await self.refresh_wifi_client_networks()
-        after = next((n for n in self._wifi_client_networks if n.id == network_id), None)
-        self.log.info('After refresh, network %s enabled=%s', network_id, after.enabled if after else None)
         return True
 
     async def _poll_info(self) -> None:

--- a/feldfreund_devkit/hardware/teltonika_router.py
+++ b/feldfreund_devkit/hardware/teltonika_router.py
@@ -48,6 +48,15 @@ class WifiInfo:
     sta_signal: int | None = None
 
 
+@dataclass(slots=True, kw_only=True)
+class WifiClientNetwork:
+    """An upstream WiFi network the router can join as a client (MultiAP station entry)."""
+    id: str
+    ssid: str
+    enabled: bool
+    encryption: str | None = None
+
+
 class TeltonikaRouter:
     """Implements the API of the builtin Teltonika RUT901 router."""
     WIFI_SIGNAL_GOOD = -67
@@ -60,6 +69,8 @@ class TeltonikaRouter:
     FAILOVER_KEYS_MOBILE = frozenset(('mob1s1a1', 'mob1s2a1'))
     INTERNET_CHECK_HOSTS = frozenset(('8.8.8.8', '1.1.1.1'))
     DNS_CHECK_HOSTNAMES = frozenset(('www.google.de', 'zauberzeug.com'))
+    WIFI_INTERFACES_ENDPOINT = 'wireless/interfaces/config'
+    WIFI_ENABLE_FIELD = 'enabled'  # RutOS config field; underlying UCI toggle is the inverse 'disabled'
 
     def __init__(self, url: str, admin_password: str) -> None:
         self.log = logging.getLogger('feldfreund.teltonika_router')
@@ -70,6 +81,7 @@ class TeltonikaRouter:
         self._modem_status: ModemStatus | None = None
         self._device_info: DeviceInfo | None = None
         self._wifi_info: WifiInfo | None = None
+        self._wifi_client_networks: list[WifiClientNetwork] = []
         self._client = httpx.AsyncClient(headers={'Content-Type': 'application/json'}, timeout=20.0)
         self._auth_token: str = ''
         self._token_time: float = 0.0
@@ -80,10 +92,13 @@ class TeltonikaRouter:
         """Emitted when the connection status changes."""
         self.INFO_UPDATED: Event = Event()
         """Emitted after modem, WiFi, and device info have been polled."""
+        self.WIFI_NETWORKS_CHANGED: Event = Event()
+        """Emitted after the upstream WiFi client network list has been refreshed."""
 
         rosys.on_repeat(self._check_connection, 5.0)
         rosys.on_repeat(self._poll_info, 30.0)
         rosys.on_startup(self._poll_device_info)
+        rosys.on_startup(self.refresh_wifi_client_networks)
         rosys.on_shutdown(self._client.aclose)
 
     @property
@@ -101,6 +116,10 @@ class TeltonikaRouter:
     @property
     def wifi_info(self) -> WifiInfo | None:
         return self._wifi_info
+
+    @property
+    def wifi_client_networks(self) -> list[WifiClientNetwork]:
+        return self._wifi_client_networks
 
     async def reboot(self) -> bool:
         """Send a reboot command to the router. Returns True on success."""
@@ -141,6 +160,72 @@ class TeltonikaRouter:
             self.log.debug('DNS resolution of %s succeeded', hostname)
             return True
         return any(await asyncio.gather(*(resolve(hostname) for hostname in hostnames)))
+
+    async def refresh_wifi_client_networks(self) -> None:
+        """Reload the upstream WiFi client networks from the router and emit ``WIFI_NETWORKS_CHANGED``."""
+        data = await self._get(self.WIFI_INTERFACES_ENDPOINT)
+        interfaces = self._normalize_interface_list(data) if data is not None else []
+        self._wifi_client_networks = [self._parse_wifi_client(i) for i in interfaces
+                                      if isinstance(i, dict) and i.get('mode') == 'sta']
+        self.WIFI_NETWORKS_CHANGED.emit()
+
+    async def add_wifi_client_network(self, ssid: str, password: str, *,
+                                      encryption: str = 'psk2', enabled: bool = False) -> str | None:
+        """Add an upstream WiFi network and return its config id, or ``None`` on failure.
+
+        The radio device and attached network are copied from an existing client entry, since
+        those depend on the router's wiring and cannot be guessed. Fails if none exists yet.
+        Refreshes the network list on success.
+
+        :param ssid: the network name to join.
+        :param password: the pre-shared key.
+        :param encryption: the encryption mode (default ``psk2``).
+        :param enabled: whether the entry is active right after creation (default ``False``).
+        :return: the created config id, or ``None`` if creation failed.
+        """
+        data = await self._get(self.WIFI_INTERFACES_ENDPOINT)
+        template = next((i for i in self._normalize_interface_list(data or [])
+                         if isinstance(i, dict) and i.get('mode') == 'sta'), None)
+        if template is None:
+            self.log.error('Cannot add WiFi client network: no existing client entry to derive device/network from')
+            return None
+        payload = {
+            'mode': 'sta',
+            'ssid': ssid,
+            'key': password,
+            'encryption': encryption,
+            'device': template.get('device'),
+            'network': template.get('network'),
+            self.WIFI_ENABLE_FIELD: '1' if enabled else '0',
+        }
+        response = await self._request('POST', self.WIFI_INTERFACES_ENDPOINT, json={'data': payload})
+        if response is None:
+            self.log.error('Failed to add WiFi client network %s', ssid)
+            return None
+        created = response.json().get('data')
+        network_id = created.get('id') if isinstance(created, dict) else None
+        self.log.info('Added WiFi client network %s (id=%s)', ssid, network_id)
+        await self.refresh_wifi_client_networks()
+        return network_id
+
+    async def remove_wifi_client_network(self, network_id: str) -> bool:
+        """Delete an upstream WiFi network by its config id, refreshing the list on success."""
+        if await self._request('DELETE', f'{self.WIFI_INTERFACES_ENDPOINT}/{network_id}') is None:
+            self.log.error('Failed to remove WiFi client network %s', network_id)
+            return False
+        self.log.info('Removed WiFi client network %s', network_id)
+        await self.refresh_wifi_client_networks()
+        return True
+
+    async def set_wifi_client_enabled(self, network_id: str, enabled: bool) -> bool:
+        """Enable or disable an upstream WiFi network by its config id, refreshing the list on success."""
+        payload = {self.WIFI_ENABLE_FIELD: '1' if enabled else '0'}
+        if await self._request('PUT', f'{self.WIFI_INTERFACES_ENDPOINT}/{network_id}', json={'data': payload}) is None:
+            self.log.error('Failed to %s WiFi client network %s', 'enable' if enabled else 'disable', network_id)
+            return False
+        self.log.info('%s WiFi client network %s', 'Enabled' if enabled else 'Disabled', network_id)
+        await self.refresh_wifi_client_networks()
+        return True
 
     async def _poll_info(self) -> None:
         tasks = [self._poll_modem_status(), self._poll_wifi_info()]
@@ -223,7 +308,7 @@ class TeltonikaRouter:
         """Perform an authenticated POST request. Returns ``True`` on success."""
         return await self._request('POST', endpoint, json=json) is not None
 
-    async def _request(self, method: Literal['GET', 'POST'], endpoint: str, *,
+    async def _request(self, method: Literal['GET', 'POST', 'PUT', 'DELETE'], endpoint: str, *,
                        json: dict | None = None) -> httpx.Response | None:
         """Perform an authenticated request, refreshing the token if needed."""
         if not await self._ensure_token():
@@ -307,6 +392,29 @@ class TeltonikaRouter:
         self._auth_token = token
         self._token_time = rosys.time()
         self.log.debug('Authentication successful')
+
+    @staticmethod
+    def _parse_wifi_client(interface: dict) -> WifiClientNetwork:
+        """Build a ``WifiClientNetwork`` from a raw interface config entry.
+
+        Reads the enable state from RutOS's ``enabled`` field but falls back to the inverse of
+        the underlying UCI ``disabled`` flag when only that is present.
+
+        :param interface: one raw entry from the wireless interfaces config response.
+        :return: the parsed client network.
+        """
+        false_values = ('0', 0, False, 'false', 'off', 'no')
+        enabled_value = interface.get('enabled')
+        if enabled_value is not None:
+            is_enabled = enabled_value not in false_values
+        else:
+            is_enabled = interface.get('disabled') in (None, *false_values)
+        return WifiClientNetwork(
+            id=interface.get('id') or interface.get('.name') or '',
+            ssid=interface.get('ssid') or '',
+            enabled=is_enabled,
+            encryption=interface.get('encryption'),
+        )
 
     @staticmethod
     def _normalize_interface_list(data: dict | list) -> list[dict]:

--- a/feldfreund_devkit/hardware/teltonika_router.py
+++ b/feldfreund_devkit/hardware/teltonika_router.py
@@ -209,11 +209,14 @@ class TeltonikaRouter:
     async def set_wifi_client_enabled(self, network_id: str, enabled: bool) -> bool:
         """Enable or disable a MultiAP candidate network by its config id, refreshing the list on success."""
         payload = {self.WIFI_ENABLE_FIELD: '1' if enabled else '0'}
-        if await self._request('PUT', f'{self.MULTI_AP_ENDPOINT}/{network_id}', json={'data': payload}) is None:
+        response = await self._request('PUT', f'{self.MULTI_AP_ENDPOINT}/{network_id}', json={'data': payload})
+        if response is None:
             self.log.error('Failed to %s MultiAP candidate network %s', 'enable' if enabled else 'disable', network_id)
             return False
-        self.log.info('%s MultiAP candidate network %s', 'Enabled' if enabled else 'Disabled', network_id)
+        self.log.info('PUT %s/%s -> %s', self.MULTI_AP_ENDPOINT, network_id, response.json())  # TEMPORARY diagnostic
         await self.refresh_wifi_client_networks()
+        after = next((n for n in self._wifi_client_networks if n.id == network_id), None)
+        self.log.info('After refresh, network %s enabled=%s', network_id, after.enabled if after else None)
         return True
 
     async def _poll_info(self) -> None:

--- a/feldfreund_devkit/hardware/teltonika_router.py
+++ b/feldfreund_devkit/hardware/teltonika_router.py
@@ -319,8 +319,11 @@ class TeltonikaRouter:
                 return None
             response.raise_for_status()
             return response
-        except httpx.HTTPError:
-            self.log.warning('%s /%s failed', method, endpoint)
+        except httpx.HTTPStatusError as e:
+            self.log.warning('%s /%s -> %s: %s', method, endpoint, e.response.status_code, e.response.text)
+            return None
+        except httpx.HTTPError as e:
+            self.log.warning('%s /%s failed: %s', method, endpoint, e or type(e).__name__)
             return None
 
     async def _check_connection(self) -> None:

--- a/feldfreund_devkit/hardware/teltonika_router.py
+++ b/feldfreund_devkit/hardware/teltonika_router.py
@@ -50,11 +50,11 @@ class WifiInfo:
 
 @dataclass(slots=True, kw_only=True)
 class WifiClientNetwork:
-    """An upstream WiFi network the router can join as a client (MultiAP station entry)."""
+    """A MultiAP candidate network the router can join as a client (one entry of the AP list)."""
     id: str
     ssid: str
     enabled: bool
-    encryption: str | None = None
+    priority: int | None = None
 
 
 class TeltonikaRouter:
@@ -69,8 +69,7 @@ class TeltonikaRouter:
     FAILOVER_KEYS_MOBILE = frozenset(('mob1s1a1', 'mob1s2a1'))
     INTERNET_CHECK_HOSTS = frozenset(('8.8.8.8', '1.1.1.1'))
     DNS_CHECK_HOSTNAMES = frozenset(('www.google.de', 'zauberzeug.com'))
-    WIFI_INTERFACES_ENDPOINT = 'wireless/interfaces/config'
-    WIFI_CLIENT_MODE = 'multi_ap'  # RutOS mode of an upstream client interface (vs. 'ap' for the broadcast network)
+    MULTI_AP_ENDPOINT = 'wireless/multi_ap/config'  # the MultiAP candidate AP list (one section per SSID)
     WIFI_ENABLE_FIELD = 'enabled'  # RutOS config field; underlying UCI toggle is the inverse 'disabled'
 
     def __init__(self, url: str, admin_password: str) -> None:
@@ -163,92 +162,57 @@ class TeltonikaRouter:
         return any(await asyncio.gather(*(resolve(hostname) for hostname in hostnames)))
 
     async def refresh_wifi_client_networks(self) -> None:
-        """Reload the upstream WiFi client networks from the router and emit ``WIFI_NETWORKS_CHANGED``."""
-        data = await self._get(self.WIFI_INTERFACES_ENDPOINT)
-        self.log.debug('Raw %s response: %s', self.WIFI_INTERFACES_ENDPOINT, data)
-        interfaces = self._normalize_interface_list(data) if data is not None else []
-        self._wifi_client_networks = [self._parse_wifi_client(i) for i in interfaces
-                                      if isinstance(i, dict) and i.get('mode') == self.WIFI_CLIENT_MODE]
-        self.log.info('Found %d upstream WiFi client network(s) among %d wireless interface(s)',
-                      len(self._wifi_client_networks), len(interfaces))
-        await self._probe_multiap_endpoints(interfaces)
+        """Reload the MultiAP candidate networks from the router and emit ``WIFI_NETWORKS_CHANGED``."""
+        data = await self._get(self.MULTI_AP_ENDPOINT)
+        entries = self._normalize_interface_list(data) if data is not None else []
+        networks = [self._parse_wifi_client(e) for e in entries if isinstance(e, dict)]
+        self._wifi_client_networks = sorted(networks, key=lambda n: (n.priority is None, n.priority))
+        self.log.info('Found %d MultiAP candidate network(s)', len(self._wifi_client_networks))
         self.WIFI_NETWORKS_CHANGED.emit()
 
-    async def _probe_multiap_endpoints(self, interfaces: list[dict]) -> None:
-        """TEMPORARY: discover where the router stores the MultiAP candidate AP list.
+    async def add_wifi_client_network(self, ssid: str, password: str, *, enabled: bool = False) -> str | None:
+        """Add a MultiAP candidate network and return its config id, or ``None`` on failure.
 
-        The candidate SSIDs (each with its own enable toggle) are not the wireless interfaces;
-        this probes likely endpoints and logs their responses so the real one can be identified.
-
-        :param interfaces: the wireless interfaces already fetched, used to derive the client id.
-        """
-        multi_ap_id = next((i.get('id') for i in interfaces
-                            if isinstance(i, dict) and i.get('mode') == self.WIFI_CLIENT_MODE), None)
-        candidates = ['wireless/multi_ap/config', 'wireless/multiap/config', 'wireless/aps/config',
-                      'wireless/access_points/config', 'wireless/multi_ap_aps/config',
-                      'multiap/aps/config', 'multiap/config']
-        if multi_ap_id is not None:
-            candidates += [f'{self.WIFI_INTERFACES_ENDPOINT}/{multi_ap_id}',
-                           f'{self.WIFI_INTERFACES_ENDPOINT}/{multi_ap_id}/aps',
-                           f'{self.WIFI_INTERFACES_ENDPOINT}/{multi_ap_id}/multi_ap']
-        for endpoint in candidates:
-            self.log.info('MultiAP endpoint probe: %s -> %s', endpoint, await self._get(endpoint))
-
-    async def add_wifi_client_network(self, ssid: str, password: str, *,
-                                      encryption: str = 'psk2', enabled: bool = False) -> str | None:
-        """Add an upstream WiFi network and return its config id, or ``None`` on failure.
-
-        The radio (``wifi_id``) and attached network are copied from an existing client entry, since
-        those depend on the router's wiring and cannot be guessed. Fails if none exists yet.
-        Refreshes the network list on success.
+        The new entry is appended with the next free priority. Refreshes the list on success.
 
         :param ssid: the network name to join.
         :param password: the pre-shared key.
-        :param encryption: the encryption mode (default ``psk2``).
         :param enabled: whether the entry is active right after creation (default ``False``).
         :return: the created config id, or ``None`` if creation failed.
         """
-        data = await self._get(self.WIFI_INTERFACES_ENDPOINT)
-        template = next((i for i in self._normalize_interface_list(data or [])
-                         if isinstance(i, dict) and i.get('mode') == self.WIFI_CLIENT_MODE), None)
-        if template is None:
-            self.log.error('Cannot add WiFi client network: no existing client entry to derive wifi_id/network from')
-            return None
+        priorities = [n.priority for n in self._wifi_client_networks if n.priority is not None]
         payload = {
-            'mode': self.WIFI_CLIENT_MODE,
             'ssid': ssid,
             'key': password,
-            'encryption': encryption,
-            'wifi_id': template.get('wifi_id'),
-            'network': template.get('network'),
+            'priority': str(max(priorities, default=0) + 1),
             self.WIFI_ENABLE_FIELD: '1' if enabled else '0',
         }
-        response = await self._request('POST', self.WIFI_INTERFACES_ENDPOINT, json={'data': payload})
+        response = await self._request('POST', self.MULTI_AP_ENDPOINT, json={'data': payload})
         if response is None:
-            self.log.error('Failed to add WiFi client network %s', ssid)
+            self.log.error('Failed to add MultiAP candidate network %s', ssid)
             return None
         created = response.json().get('data')
         network_id = created.get('id') if isinstance(created, dict) else None
-        self.log.info('Added WiFi client network %s (id=%s)', ssid, network_id)
+        self.log.info('Added MultiAP candidate network %s (id=%s)', ssid, network_id)
         await self.refresh_wifi_client_networks()
         return network_id
 
     async def remove_wifi_client_network(self, network_id: str) -> bool:
-        """Delete an upstream WiFi network by its config id, refreshing the list on success."""
-        if await self._request('DELETE', f'{self.WIFI_INTERFACES_ENDPOINT}/{network_id}') is None:
-            self.log.error('Failed to remove WiFi client network %s', network_id)
+        """Delete a MultiAP candidate network by its config id, refreshing the list on success."""
+        if await self._request('DELETE', f'{self.MULTI_AP_ENDPOINT}/{network_id}') is None:
+            self.log.error('Failed to remove MultiAP candidate network %s', network_id)
             return False
-        self.log.info('Removed WiFi client network %s', network_id)
+        self.log.info('Removed MultiAP candidate network %s', network_id)
         await self.refresh_wifi_client_networks()
         return True
 
     async def set_wifi_client_enabled(self, network_id: str, enabled: bool) -> bool:
-        """Enable or disable an upstream WiFi network by its config id, refreshing the list on success."""
+        """Enable or disable a MultiAP candidate network by its config id, refreshing the list on success."""
         payload = {self.WIFI_ENABLE_FIELD: '1' if enabled else '0'}
-        if await self._request('PUT', f'{self.WIFI_INTERFACES_ENDPOINT}/{network_id}', json={'data': payload}) is None:
-            self.log.error('Failed to %s WiFi client network %s', 'enable' if enabled else 'disable', network_id)
+        if await self._request('PUT', f'{self.MULTI_AP_ENDPOINT}/{network_id}', json={'data': payload}) is None:
+            self.log.error('Failed to %s MultiAP candidate network %s', 'enable' if enabled else 'disable', network_id)
             return False
-        self.log.info('%s WiFi client network %s', 'Enabled' if enabled else 'Disabled', network_id)
+        self.log.info('%s MultiAP candidate network %s', 'Enabled' if enabled else 'Disabled', network_id)
         await self.refresh_wifi_client_networks()
         return True
 
@@ -419,26 +383,27 @@ class TeltonikaRouter:
         self.log.debug('Authentication successful')
 
     @staticmethod
-    def _parse_wifi_client(interface: dict) -> WifiClientNetwork:
-        """Build a ``WifiClientNetwork`` from a raw interface config entry.
+    def _parse_wifi_client(entry: dict) -> WifiClientNetwork:
+        """Build a ``WifiClientNetwork`` from a raw MultiAP candidate config entry.
 
         Reads the enable state from RutOS's ``enabled`` field but falls back to the inverse of
         the underlying UCI ``disabled`` flag when only that is present.
 
-        :param interface: one raw entry from the wireless interfaces config response.
-        :return: the parsed client network.
+        :param entry: one raw entry from the MultiAP config response.
+        :return: the parsed candidate network.
         """
         false_values = ('0', 0, False, 'false', 'off', 'no')
-        enabled_value = interface.get('enabled')
+        enabled_value = entry.get('enabled')
         if enabled_value is not None:
             is_enabled = enabled_value not in false_values
         else:
-            is_enabled = interface.get('disabled') in (None, *false_values)
+            is_enabled = entry.get('disabled') in (None, *false_values)
+        priority = entry.get('priority')
         return WifiClientNetwork(
-            id=interface.get('id') or interface.get('.name') or '',
-            ssid=interface.get('ssid') or '',
+            id=entry.get('id') or entry.get('.name') or '',
+            ssid=entry.get('ssid') or '',
             enabled=is_enabled,
-            encryption=interface.get('encryption'),
+            priority=int(priority) if priority is not None and str(priority).isdigit() else None,
         )
 
     @staticmethod

--- a/feldfreund_devkit/interface/components/teltonika_ui.py
+++ b/feldfreund_devkit/interface/components/teltonika_ui.py
@@ -123,10 +123,7 @@ def teltonika_ui(router: TeltonikaRouter) -> None:
             ui.label('No upstream WiFi networks configured.').classes('text-sm text-grey')
         for network in router.wifi_client_networks:
             with ui.row().classes('w-full items-center justify-between no-wrap'):
-                with ui.column().classes('gap-0 min-w-0'):
-                    ui.label(network.ssid or '(hidden)').classes('truncate')
-                    if network.priority is not None:
-                        ui.label(f'priority {network.priority}').classes('text-xs text-grey')
+                ui.label(network.ssid or '(hidden)').classes('truncate min-w-0')
                 with ui.row().classes('items-center gap-1 no-wrap'):
                     ui.switch(value=network.enabled,
                               on_change=lambda e, n=network: toggle_network(n, e.value)) \

--- a/feldfreund_devkit/interface/components/teltonika_ui.py
+++ b/feldfreund_devkit/interface/components/teltonika_ui.py
@@ -176,7 +176,8 @@ def teltonika_ui(router: TeltonikaRouter) -> None:
     expansions: dict[str, ui.expansion] = {}
     with ui.column().classes('w-full gap-1'):
         ui.label('Teltonika Router').classes('text-center text-bold')
-        with ui.row().classes('gap-1 items-center'):
+        with ui.row().classes('w-full gap-1 pb-5'):
+            ui.label('Status:').props('align-left')
             teltonika_status_widget(router)
             ui.space()
             ui.button('Check Internet', on_click=handle_ping).props('dense size=sm')

--- a/feldfreund_devkit/interface/components/teltonika_ui.py
+++ b/feldfreund_devkit/interface/components/teltonika_ui.py
@@ -81,6 +81,7 @@ def teltonika_ui(router: TeltonikaRouter) -> None:
         if await router.set_wifi_client_enabled(network.id, target):
             rosys.notify(f'{action}d WiFi network "{network.ssid}"', 'positive')
         else:
+            _networks.refresh()  # revert the switch to the unchanged state
             rosys.notify(f'Failed to {action.lower()} WiFi network', 'negative')
 
     async def delete_network(network: WifiClientNetwork) -> None:

--- a/feldfreund_devkit/interface/components/teltonika_ui.py
+++ b/feldfreund_devkit/interface/components/teltonika_ui.py
@@ -11,7 +11,6 @@ from .confirm_dialog import ConfirmDialog
 if TYPE_CHECKING:
     from ...hardware import TeltonikaRouter, WifiClientNetwork
 
-ENCRYPTION_OPTIONS = ['psk2', 'sae', 'none']
 EXPANSION_STORAGE_PREFIX = 'teltonika_expansion_'
 
 
@@ -96,7 +95,6 @@ def teltonika_ui(router: TeltonikaRouter) -> None:
             ui.label('Add WiFi network').classes('text-bold')
             ssid_input = ui.input('SSID').classes('w-full')
             password_input = ui.input('Password', password=True, password_toggle_button=True).classes('w-full')
-            encryption_select = ui.select(ENCRYPTION_OPTIONS, value='psk2', label='Encryption').classes('w-full')
             with ui.row():
                 ui.button('Add', on_click=lambda: dialog.submit(True))
                 ui.button('Cancel', on_click=lambda: dialog.submit(False)).props('flat')
@@ -106,7 +104,7 @@ def teltonika_ui(router: TeltonikaRouter) -> None:
         if not ssid:
             rosys.notify('SSID must not be empty', 'warning')
             return
-        if await router.add_wifi_client_network(ssid, password_input.value, encryption=encryption_select.value):
+        if await router.add_wifi_client_network(ssid, password_input.value):
             rosys.notify(f'Added WiFi network "{ssid}"', 'positive')
         else:
             rosys.notify('Failed to add WiFi network', 'negative')
@@ -127,8 +125,8 @@ def teltonika_ui(router: TeltonikaRouter) -> None:
             with ui.row().classes('w-full items-center justify-between no-wrap'):
                 with ui.column().classes('gap-0 min-w-0'):
                     ui.label(network.ssid or '(hidden)').classes('truncate')
-                    if network.encryption:
-                        ui.label(network.encryption).classes('text-xs text-grey')
+                    if network.priority is not None:
+                        ui.label(f'priority {network.priority}').classes('text-xs text-grey')
                 with ui.row().classes('items-center gap-1 no-wrap'):
                     ui.switch(value=network.enabled,
                               on_change=lambda e, n=network: toggle_network(n, e.value)) \

--- a/feldfreund_devkit/interface/components/teltonika_ui.py
+++ b/feldfreund_devkit/interface/components/teltonika_ui.py
@@ -4,7 +4,7 @@ import asyncio
 from typing import TYPE_CHECKING
 
 import rosys
-from nicegui import app, ui
+from nicegui import app, background_tasks, ui
 
 from .confirm_dialog import ConfirmDialog
 
@@ -196,19 +196,17 @@ def teltonika_ui(router: TeltonikaRouter) -> None:
             ui.button('Check Internet', icon='network_ping', on_click=handle_ping).props('outline')
             ui.button('Reboot Router', icon='restart_alt', on_click=handle_reboot, color='negative').props('outline')
 
-    bound = False
+    client = ui.context.client
 
-    def _persist_expansions(_=None) -> None:
-        nonlocal bound
-        if bound:  # on_connect fires again on reconnect; bind only once
-            return
-        bound = True
-        for name, expansion in expansions.items():
-            key = f'{EXPANSION_STORAGE_PREFIX}{name}'
-            if key not in app.storage.tab:
-                app.storage.tab[key] = expansion.value  # seed the constructed default before binding
-            expansion.bind_value(app.storage.tab, key)
-    ui.context.client.on_connect(_persist_expansions)  # app.storage.tab needs an established connection
+    async def _persist_expansions() -> None:
+        await client.connected()  # app.storage.tab is only created once the tab connection is established
+        with client:  # restore the client context inside the background task
+            for name, expansion in expansions.items():
+                key = f'{EXPANSION_STORAGE_PREFIX}{name}'
+                if key not in app.storage.tab:
+                    app.storage.tab[key] = expansion.value  # seed the constructed default before binding
+                expansion.bind_value(app.storage.tab, key)
+    background_tasks.create(_persist_expansions(), name='teltonika expansion persistence')
 
     router.CONNECTION_CHANGED.subscribe(_refresh_status, unsubscribe_on_delete=True)
     router.INFO_UPDATED.subscribe(_refresh_status, unsubscribe_on_delete=True)

--- a/feldfreund_devkit/interface/components/teltonika_ui.py
+++ b/feldfreund_devkit/interface/components/teltonika_ui.py
@@ -7,6 +7,7 @@ import rosys
 from nicegui import app, ui
 
 from .confirm_dialog import ConfirmDialog
+from .teltonika_status_widget import teltonika_status_widget
 
 if TYPE_CHECKING:
     from ...hardware import TeltonikaRouter, WifiClientNetwork
@@ -175,7 +176,9 @@ def teltonika_ui(router: TeltonikaRouter) -> None:
     expansions: dict[str, ui.expansion] = {}
     with ui.column().classes('w-full gap-1'):
         ui.label('Teltonika Router').classes('text-center text-bold')
-        with ui.row().classes('gap-1'):
+        with ui.row().classes('gap-1 items-center'):
+            teltonika_status_widget(router)
+            ui.space()
             ui.button('Check Internet', on_click=handle_ping).props('dense size=sm')
             ui.button('Reboot Router', on_click=handle_reboot, color='negative').props('dense size=sm')
         with ui.expansion('Router', icon='router', value=True).classes('w-full').props('dense') as expansions['router']:

--- a/feldfreund_devkit/interface/components/teltonika_ui.py
+++ b/feldfreund_devkit/interface/components/teltonika_ui.py
@@ -4,7 +4,7 @@ import asyncio
 from typing import TYPE_CHECKING
 
 import rosys
-from nicegui import app, background_tasks, ui
+from nicegui import app, ui
 
 from .confirm_dialog import ConfirmDialog
 
@@ -196,17 +196,11 @@ def teltonika_ui(router: TeltonikaRouter) -> None:
             ui.button('Check Internet', icon='network_ping', on_click=handle_ping).props('outline')
             ui.button('Reboot Router', icon='restart_alt', on_click=handle_reboot, color='negative').props('outline')
 
-    client = ui.context.client
-
-    async def _persist_expansions() -> None:
-        await client.connected()  # app.storage.tab is only created once the tab connection is established
-        with client:  # restore the client context inside the background task
-            for name, expansion in expansions.items():
-                key = f'{EXPANSION_STORAGE_PREFIX}{name}'
-                if key not in app.storage.tab:
-                    app.storage.tab[key] = expansion.value  # seed the constructed default before binding
-                expansion.bind_value(app.storage.tab, key)
-    background_tasks.create(_persist_expansions(), name='teltonika expansion persistence')
+    for name, expansion in expansions.items():
+        key = f'{EXPANSION_STORAGE_PREFIX}{name}'
+        if key not in app.storage.user:
+            app.storage.user[key] = expansion.value  # seed the constructed default (bind syncs storage -> element)
+        expansion.bind_value(app.storage.user, key)
 
     router.CONNECTION_CHANGED.subscribe(_refresh_status, unsubscribe_on_delete=True)
     router.INFO_UPDATED.subscribe(_refresh_status, unsubscribe_on_delete=True)

--- a/feldfreund_devkit/interface/components/teltonika_ui.py
+++ b/feldfreund_devkit/interface/components/teltonika_ui.py
@@ -4,7 +4,7 @@ import asyncio
 from typing import TYPE_CHECKING
 
 import rosys
-from nicegui import ui
+from nicegui import app, ui
 
 from .confirm_dialog import ConfirmDialog
 
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from ...hardware import TeltonikaRouter, WifiClientNetwork
 
 ENCRYPTION_OPTIONS = ['psk2', 'sae', 'none']
+EXPANSION_STORAGE_PREFIX = 'teltonika_expansion_'
 
 
 def _format_value(value: str | int | None, unit: str = '') -> str:
@@ -110,11 +111,15 @@ def teltonika_ui(router: TeltonikaRouter) -> None:
         else:
             rosys.notify('Failed to add WiFi network', 'negative')
 
+    async def refresh_networks() -> None:
+        await router.refresh_wifi_client_networks()
+        rosys.notify(f'Found {len(router.wifi_client_networks)} upstream WiFi network(s)', 'info')
+
     @ui.refreshable
     def _networks() -> None:
         with ui.row().classes('w-full items-center justify-between no-wrap'):
             ui.label('Upstream WiFi networks').classes('text-sm text-grey')
-            ui.button(icon='refresh', on_click=router.refresh_wifi_client_networks) \
+            ui.button(icon='refresh', on_click=refresh_networks) \
                 .props('flat dense round').tooltip('Reload the network list from the router')
         if not router.wifi_client_networks:
             ui.label('No upstream WiFi networks configured.').classes('text-sm text-grey')
@@ -133,15 +138,26 @@ def teltonika_ui(router: TeltonikaRouter) -> None:
         ui.button('Add network', icon='add', on_click=add_network).props('flat dense')
 
     @ui.refreshable
-    def _status() -> None:
-        with ui.expansion('Router', icon='router').classes('w-full').props('default-opened dense'):
-            _device_section(router)
-        with ui.expansion('Mobile', icon='lte_mobiledata').classes('w-full').props('dense'):
-            _mobile_section(router)
-        with ui.expansion('Access Point', icon='wifi_tethering').classes('w-full').props('dense'):
-            _ap_section(router)
-        with ui.expansion('Upstream WiFi', icon='wifi').classes('w-full').props('dense'):
-            _multi_ap_section(router)
+    def _device() -> None:
+        _device_section(router)
+
+    @ui.refreshable
+    def _mobile() -> None:
+        _mobile_section(router)
+
+    @ui.refreshable
+    def _ap() -> None:
+        _ap_section(router)
+
+    @ui.refreshable
+    def _multi_ap() -> None:
+        _multi_ap_section(router)
+
+    def _refresh_status() -> None:
+        _device.refresh()
+        _mobile.refresh()
+        _ap.refresh()
+        _multi_ap.refresh()
 
     async def handle_reboot() -> None:
         if not await ConfirmDialog('Really reboot the router?'):
@@ -162,14 +178,38 @@ def teltonika_ui(router: TeltonikaRouter) -> None:
         else:
             rosys.notify('No internet connection', 'negative')
 
+    expansions: dict[str, ui.expansion] = {}
     with ui.column().classes('w-full gap-1'):
-        _status()
-        with ui.expansion('WiFi Networks', icon='settings_ethernet').classes('w-full').props('dense'):
+        with ui.expansion('Router', icon='router', value=True).classes('w-full').props('dense') as expansions['router']:
+            _device()
+        with ui.expansion('Mobile', icon='lte_mobiledata').classes('w-full').props('dense') as expansions['mobile']:
+            _mobile()
+        with ui.expansion('Access Point', icon='wifi_tethering') \
+                .classes('w-full').props('dense') as expansions['access_point']:
+            _ap()
+        with ui.expansion('Upstream WiFi', icon='wifi').classes('w-full').props('dense') as expansions['upstream_wifi']:
+            _multi_ap()
+        with ui.expansion('WiFi Networks', icon='settings_ethernet') \
+                .classes('w-full').props('dense') as expansions['wifi_networks']:
             _networks()
         with ui.row().classes('mt-2'):
             ui.button('Check Internet', icon='network_ping', on_click=handle_ping).props('outline')
             ui.button('Reboot Router', icon='restart_alt', on_click=handle_reboot, color='negative').props('outline')
 
-    router.CONNECTION_CHANGED.subscribe(_status.refresh, unsubscribe_on_delete=True)
-    router.INFO_UPDATED.subscribe(_status.refresh, unsubscribe_on_delete=True)
+    bound = False
+
+    def _persist_expansions(_=None) -> None:
+        nonlocal bound
+        if bound:  # on_connect fires again on reconnect; bind only once
+            return
+        bound = True
+        for name, expansion in expansions.items():
+            key = f'{EXPANSION_STORAGE_PREFIX}{name}'
+            if key not in app.storage.tab:
+                app.storage.tab[key] = expansion.value  # seed the constructed default before binding
+            expansion.bind_value(app.storage.tab, key)
+    ui.context.client.on_connect(_persist_expansions)  # app.storage.tab needs an established connection
+
+    router.CONNECTION_CHANGED.subscribe(_refresh_status, unsubscribe_on_delete=True)
+    router.INFO_UPDATED.subscribe(_refresh_status, unsubscribe_on_delete=True)
     router.WIFI_NETWORKS_CHANGED.subscribe(_networks.refresh, unsubscribe_on_delete=True)

--- a/feldfreund_devkit/interface/components/teltonika_ui.py
+++ b/feldfreund_devkit/interface/components/teltonika_ui.py
@@ -123,13 +123,13 @@ def teltonika_ui(router: TeltonikaRouter) -> None:
             ui.label('No upstream WiFi networks configured.').classes('text-sm text-grey')
         for network in router.wifi_client_networks:
             with ui.row().classes('w-full items-center justify-between no-wrap'):
-                ui.label(network.ssid or '(hidden)').classes('truncate min-w-0')
+                ui.label(network.ssid or '(hidden)').classes('truncate min-w-0 text-sm')
                 with ui.row().classes('items-center gap-1 no-wrap'):
                     ui.switch(value=network.enabled,
                               on_change=lambda e, n=network: toggle_network(n, e.value)) \
-                        .tooltip('Enable or disable this network')
+                        .props('dense size=sm').tooltip('Enable or disable this network')
                     ui.button(icon='delete', on_click=lambda _, n=network: delete_network(n)) \
-                        .props('flat dense round color=negative').tooltip('Delete this network')
+                        .props('flat dense round size=sm color=negative').tooltip('Delete this network')
 
     @ui.refreshable
     def _device() -> None:

--- a/feldfreund_devkit/interface/components/teltonika_ui.py
+++ b/feldfreund_devkit/interface/components/teltonika_ui.py
@@ -9,7 +9,9 @@ from nicegui import ui
 from .confirm_dialog import ConfirmDialog
 
 if TYPE_CHECKING:
-    from ...hardware import TeltonikaRouter
+    from ...hardware import TeltonikaRouter, WifiClientNetwork
+
+ENCRYPTION_OPTIONS = ['psk2', 'sae', 'none']
 
 
 def _format_value(value: str | int | None, unit: str = '') -> str:
@@ -19,9 +21,9 @@ def _format_value(value: str | int | None, unit: str = '') -> str:
 
 def _device_section(router: TeltonikaRouter) -> None:
     device = router.device_info
-    title = device.model if device and device.model else 'Teltonika Router'
-    ui.label(title).classes('text-bold')
     with ui.grid(columns=2).classes('w-full gap-x-4 gap-y-1'):
+        ui.label('Model:').tooltip('Router model name')
+        ui.label(_format_value(device.model) if device else '-')
         ui.label('Connection:').tooltip('Active failover interface type')
         ui.label(router.connection_status.value.upper())
         ui.label('Firmware:').tooltip('RutOS firmware version')
@@ -31,7 +33,6 @@ def _device_section(router: TeltonikaRouter) -> None:
 
 
 def _mobile_section(router: TeltonikaRouter) -> None:
-    ui.label('Mobile').classes('font-bold')
     modem = router.modem_status
     with ui.grid(columns=2).classes('w-full gap-x-4 gap-y-1'):
         ui.label('Operator:').tooltip('Mobile network operator')
@@ -51,7 +52,6 @@ def _mobile_section(router: TeltonikaRouter) -> None:
 
 
 def _ap_section(router: TeltonikaRouter) -> None:
-    ui.label('AP').classes('font-bold')
     wifi = router.wifi_info
     with ui.grid(columns=2).classes('w-full gap-x-4 gap-y-1'):
         ui.label('SSID:').tooltip('Broadcast WiFi network name')
@@ -61,7 +61,6 @@ def _ap_section(router: TeltonikaRouter) -> None:
 
 
 def _multi_ap_section(router: TeltonikaRouter) -> None:
-    ui.label('Multi AP').classes('font-bold')
     wifi = router.wifi_info
     with ui.grid(columns=2).classes('w-full gap-x-4 gap-y-1'):
         ui.label('SSID:').tooltip('Upstream WiFi network the router connects to')
@@ -71,39 +70,106 @@ def _multi_ap_section(router: TeltonikaRouter) -> None:
 
 
 def teltonika_ui(router: TeltonikaRouter) -> None:
+    async def toggle_network(network: WifiClientNetwork, target: bool) -> None:
+        if target == network.enabled:
+            return
+        action = 'Enable' if target else 'Disable'
+        if not await ConfirmDialog(f'{action} WiFi network "{network.ssid}"?'):
+            _networks.refresh()  # revert the switch to the unchanged state
+            return
+        if await router.set_wifi_client_enabled(network.id, target):
+            rosys.notify(f'{action}d WiFi network "{network.ssid}"', 'positive')
+        else:
+            rosys.notify(f'Failed to {action.lower()} WiFi network', 'negative')
+
+    async def delete_network(network: WifiClientNetwork) -> None:
+        if not await ConfirmDialog(f'Delete WiFi network "{network.ssid}"?'):
+            return
+        if await router.remove_wifi_client_network(network.id):
+            rosys.notify(f'Deleted WiFi network "{network.ssid}"', 'positive')
+        else:
+            rosys.notify('Failed to delete WiFi network', 'negative')
+
+    async def add_network() -> None:
+        with ui.dialog() as dialog, ui.card():
+            ui.label('Add WiFi network').classes('text-bold')
+            ssid_input = ui.input('SSID').classes('w-full')
+            password_input = ui.input('Password', password=True, password_toggle_button=True).classes('w-full')
+            encryption_select = ui.select(ENCRYPTION_OPTIONS, value='psk2', label='Encryption').classes('w-full')
+            with ui.row():
+                ui.button('Add', on_click=lambda: dialog.submit(True))
+                ui.button('Cancel', on_click=lambda: dialog.submit(False)).props('flat')
+        if not await dialog:
+            return
+        ssid = ssid_input.value.strip()
+        if not ssid:
+            rosys.notify('SSID must not be empty', 'warning')
+            return
+        if await router.add_wifi_client_network(ssid, password_input.value, encryption=encryption_select.value):
+            rosys.notify(f'Added WiFi network "{ssid}"', 'positive')
+        else:
+            rosys.notify('Failed to add WiFi network', 'negative')
+
     @ui.refreshable
-    def _ui() -> None:
-        _device_section(router)
-        ui.separator()
-        _mobile_section(router)
-        ui.separator()
-        _ap_section(router)
-        ui.separator()
-        _multi_ap_section(router)
+    def _networks() -> None:
+        with ui.row().classes('w-full items-center justify-between no-wrap'):
+            ui.label('Upstream WiFi networks').classes('text-sm text-grey')
+            ui.button(icon='refresh', on_click=router.refresh_wifi_client_networks) \
+                .props('flat dense round').tooltip('Reload the network list from the router')
+        if not router.wifi_client_networks:
+            ui.label('No upstream WiFi networks configured.').classes('text-sm text-grey')
+        for network in router.wifi_client_networks:
+            with ui.row().classes('w-full items-center justify-between no-wrap'):
+                with ui.column().classes('gap-0 min-w-0'):
+                    ui.label(network.ssid or '(hidden)').classes('truncate')
+                    if network.encryption:
+                        ui.label(network.encryption).classes('text-xs text-grey')
+                with ui.row().classes('items-center gap-1 no-wrap'):
+                    ui.switch(value=network.enabled,
+                              on_change=lambda e, n=network: toggle_network(n, e.value)) \
+                        .tooltip('Enable or disable this network')
+                    ui.button(icon='delete', on_click=lambda _, n=network: delete_network(n)) \
+                        .props('flat dense round color=negative').tooltip('Delete this network')
+        ui.button('Add network', icon='add', on_click=add_network).props('flat dense')
 
-        async def handle_reboot() -> None:
-            if not await ConfirmDialog('Really reboot the router?'):
-                return
-            if await router.reboot():
-                ui.notify('Router reboot initiated', type='positive')
-            else:
-                ui.notify('Router reboot failed', type='negative')
+    @ui.refreshable
+    def _status() -> None:
+        with ui.expansion('Router', icon='router').classes('w-full').props('default-opened dense'):
+            _device_section(router)
+        with ui.expansion('Mobile', icon='lte_mobiledata').classes('w-full').props('dense'):
+            _mobile_section(router)
+        with ui.expansion('Access Point', icon='wifi_tethering').classes('w-full').props('dense'):
+            _ap_section(router)
+        with ui.expansion('Upstream WiFi', icon='wifi').classes('w-full').props('dense'):
+            _multi_ap_section(router)
 
-        async def handle_ping() -> None:
-            connectivity, dns = await asyncio.gather(router.check_internet(), router.check_dns())
-            if connectivity and dns:
-                rosys.notify('Internet reachable', 'positive')
-            elif connectivity:
-                rosys.notify('Internet reachable, but DNS not resolving', 'warning')
-            elif dns:
-                rosys.notify('DNS resolves, but no IP connectivity', 'warning')
-            else:
-                rosys.notify('No internet connection', 'negative')
+    async def handle_reboot() -> None:
+        if not await ConfirmDialog('Really reboot the router?'):
+            return
+        if await router.reboot():
+            ui.notify('Router reboot initiated', type='positive')
+        else:
+            ui.notify('Router reboot failed', type='negative')
 
-        with ui.row():
+    async def handle_ping() -> None:
+        connectivity, dns = await asyncio.gather(router.check_internet(), router.check_dns())
+        if connectivity and dns:
+            rosys.notify('Internet reachable', 'positive')
+        elif connectivity:
+            rosys.notify('Internet reachable, but DNS not resolving', 'warning')
+        elif dns:
+            rosys.notify('DNS resolves, but no IP connectivity', 'warning')
+        else:
+            rosys.notify('No internet connection', 'negative')
+
+    with ui.column().classes('w-full gap-1'):
+        _status()
+        with ui.expansion('WiFi Networks', icon='settings_ethernet').classes('w-full').props('dense'):
+            _networks()
+        with ui.row().classes('mt-2'):
             ui.button('Check Internet', icon='network_ping', on_click=handle_ping).props('outline')
-            ui.button('Reboot Router', icon='restart_alt', on_click=handle_reboot, color='negative') \
-                .props('outline')
-    _ui()
-    router.CONNECTION_CHANGED.subscribe(_ui.refresh, unsubscribe_on_delete=True)
-    router.INFO_UPDATED.subscribe(_ui.refresh, unsubscribe_on_delete=True)
+            ui.button('Reboot Router', icon='restart_alt', on_click=handle_reboot, color='negative').props('outline')
+
+    router.CONNECTION_CHANGED.subscribe(_status.refresh, unsubscribe_on_delete=True)
+    router.INFO_UPDATED.subscribe(_status.refresh, unsubscribe_on_delete=True)
+    router.WIFI_NETWORKS_CHANGED.subscribe(_networks.refresh, unsubscribe_on_delete=True)

--- a/feldfreund_devkit/interface/components/teltonika_ui.py
+++ b/feldfreund_devkit/interface/components/teltonika_ui.py
@@ -118,7 +118,7 @@ def teltonika_ui(router: TeltonikaRouter) -> None:
     @ui.refreshable
     def _networks() -> None:
         with ui.row().classes('w-full items-center justify-between no-wrap'):
-            ui.label('Upstream WiFi networks').classes('text-sm text-grey')
+            ui.button('Add network', icon='add', on_click=add_network).props('flat dense')
             ui.button(icon='refresh', on_click=refresh_networks) \
                 .props('flat dense round').tooltip('Reload the network list from the router')
         if not router.wifi_client_networks:
@@ -135,7 +135,6 @@ def teltonika_ui(router: TeltonikaRouter) -> None:
                         .tooltip('Enable or disable this network')
                     ui.button(icon='delete', on_click=lambda _, n=network: delete_network(n)) \
                         .props('flat dense round color=negative').tooltip('Delete this network')
-        ui.button('Add network', icon='add', on_click=add_network).props('flat dense')
 
     @ui.refreshable
     def _device() -> None:
@@ -180,6 +179,10 @@ def teltonika_ui(router: TeltonikaRouter) -> None:
 
     expansions: dict[str, ui.expansion] = {}
     with ui.column().classes('w-full gap-1'):
+        ui.label('Teltonika Router').classes('text-center text-bold')
+        with ui.row().classes('gap-1'):
+            ui.button('Check Internet', on_click=handle_ping).props('dense size=sm')
+            ui.button('Reboot Router', on_click=handle_reboot, color='negative').props('dense size=sm')
         with ui.expansion('Router', icon='router', value=True).classes('w-full').props('dense') as expansions['router']:
             _device()
         with ui.expansion('Mobile', icon='lte_mobiledata').classes('w-full').props('dense') as expansions['mobile']:
@@ -192,9 +195,6 @@ def teltonika_ui(router: TeltonikaRouter) -> None:
         with ui.expansion('WiFi Networks', icon='settings_ethernet') \
                 .classes('w-full').props('dense') as expansions['wifi_networks']:
             _networks()
-        with ui.row().classes('mt-2'):
-            ui.button('Check Internet', icon='network_ping', on_click=handle_ping).props('outline')
-            ui.button('Reboot Router', icon='restart_alt', on_click=handle_reboot, color='negative').props('outline')
 
     for name, expansion in expansions.items():
         key = f'{EXPANSION_STORAGE_PREFIX}{name}'

--- a/tests/test_teltonika_router.py
+++ b/tests/test_teltonika_router.py
@@ -5,32 +5,33 @@ import rosys
 
 from feldfreund_devkit.hardware.teltonika_router import TeltonikaRouter
 
-BASE_PATH = '/api/wireless/interfaces/config'
+BASE_PATH = '/api/wireless/multi_ap/config'
 
 
-def _client(section_id: str, ssid: str, *, enabled: str = '1', **extra: str) -> dict:
-    """Build a raw upstream-client interface config entry as the RutOS API returns it.
+def _entry(section_id: str, ssid: str, *, enabled: str = '1', priority: str, **extra: str) -> dict:
+    """Build a raw MultiAP candidate config entry as the RutOS API returns it.
 
     :param section_id: the config section id.
     :param ssid: the network name.
     :param enabled: the RutOS ``enabled`` flag ('1' or '0').
+    :param priority: the connection priority.
     :param extra: additional raw fields to merge in.
-    :return: the raw interface dict.
+    :return: the raw entry dict.
     """
-    return {'id': section_id, 'mode': 'multi_ap', 'ssid': ssid, 'enabled': enabled,
-            'encryption': 'psk2', 'wifi_id': 'radio0', 'network': 'wwan', **extra}
+    return {'id': section_id, 'ssid': ssid, 'key': 'secret', 'enabled': enabled,
+            'priority': priority, '.type': 'wifi-iface', **extra}
 
 
-class FakeRouterApi:
-    """A stateful RutOS wireless-config endpoint backed by an in-memory interface list."""
+class FakeMultiApApi:
+    """A stateful RutOS ``wireless/multi_ap/config`` endpoint backed by an in-memory entry list."""
 
-    def __init__(self, interfaces: list[dict]) -> None:
-        self.interfaces = interfaces
+    def __init__(self, entries: list[dict]) -> None:
+        self.entries = entries
         self.requests: list[tuple[str, str, dict | None]] = []
-        self._counter = 0
+        self._counter = len(entries)  # new ids continue past the seeded entries
 
     def handler(self, request: httpx.Request) -> httpx.Response:
-        """Serve GET/POST/PUT/DELETE against the in-memory interface list.
+        """Serve GET/POST/PUT/DELETE against the in-memory entry list.
 
         :param request: the intercepted HTTP request.
         :return: the mocked response.
@@ -40,26 +41,26 @@ class FakeRouterApi:
         path = request.url.path
         if path == BASE_PATH:
             if request.method == 'GET':
-                return httpx.Response(200, json={'data': self.interfaces})
+                return httpx.Response(200, json={'data': self.entries})
             if request.method == 'POST':
                 self._counter += 1
-                section_id = f'cfg{self._counter}'
-                self.interfaces.append({**body, 'id': section_id, '.name': section_id})
+                section_id = str(self._counter)
+                self.entries.append({**body, 'id': section_id, '.type': 'wifi-iface'})
                 return httpx.Response(200, json={'data': {'id': section_id}})
         if path.startswith(f'{BASE_PATH}/'):
             section_id = path.rsplit('/', 1)[1]
             if request.method == 'PUT':
-                for interface in self.interfaces:
-                    if interface.get('id') == section_id:
-                        interface.update(body)
+                for entry in self.entries:
+                    if entry.get('id') == section_id:
+                        entry.update(body)
                 return httpx.Response(200, json={'data': {'id': section_id}})
             if request.method == 'DELETE':
-                self.interfaces = [i for i in self.interfaces if i.get('id') != section_id]
+                self.entries = [e for e in self.entries if e.get('id') != section_id]
                 return httpx.Response(200, json={'data': {}})
         return httpx.Response(404, json={'error': 'not found'})
 
 
-def _make_router(api: FakeRouterApi) -> TeltonikaRouter:
+def _make_router(api: FakeMultiApApi) -> TeltonikaRouter:
     """Create a router wired to a mocked transport with a pre-seeded auth token.
 
     :param api: the fake API whose handler backs the mock transport.
@@ -74,24 +75,23 @@ def _make_router(api: FakeRouterApi) -> TeltonikaRouter:
     return router
 
 
-async def test_refresh_lists_only_client_networks(rosys_integration):
-    """Refreshing keeps only upstream-client interfaces and parses their enabled state."""
-    api = FakeRouterApi([
-        _client('cfg_a', 'Barn', enabled='1'),
-        {'id': 'cfg_ap', 'mode': 'ap', 'ssid': 'RobotAP', 'enabled': '1'},
-        _client('cfg_b', 'Shed', enabled='0'),
+async def test_refresh_parses_and_sorts_by_priority(rosys_integration):
+    """Refreshing parses enabled state and orders the candidates by priority."""
+    api = FakeMultiApApi([
+        _entry('2', 'Shed', enabled='0', priority='2'),
+        _entry('1', 'Barn', enabled='1', priority='1'),
     ])
     router = _make_router(api)
     await router.refresh_wifi_client_networks()
     networks = router.wifi_client_networks
     assert [n.ssid for n in networks] == ['Barn', 'Shed']
     assert [n.enabled for n in networks] == [True, False]
-    assert networks[0].id == 'cfg_a'
+    assert [n.priority for n in networks] == [1, 2]
 
 
 async def test_refresh_emits_event(rosys_integration):
     """Refreshing emits WIFI_NETWORKS_CHANGED."""
-    api = FakeRouterApi([_client('cfg_a', 'Barn')])
+    api = FakeMultiApApi([_entry('1', 'Barn', priority='1')])
     router = _make_router(api)
     events = 0
 
@@ -105,40 +105,42 @@ async def test_refresh_emits_event(rosys_integration):
 
 async def test_set_enabled_sends_put_and_refreshes(rosys_integration):
     """Toggling sends a PUT with the enabled flag and refreshes the cached list."""
-    api = FakeRouterApi([_client('cfg_a', 'Barn', enabled='1')])
+    api = FakeMultiApApi([_entry('1', 'Barn', enabled='1', priority='1')])
     router = _make_router(api)
-    assert await router.set_wifi_client_enabled('cfg_a', False)
+    assert await router.set_wifi_client_enabled('1', False)
     put_requests = [r for r in api.requests if r[0] == 'PUT']
-    assert put_requests == [('PUT', f'{BASE_PATH}/cfg_a', {'enabled': '0'})]
+    assert put_requests == [('PUT', f'{BASE_PATH}/1', {'enabled': '0'})]
     assert router.wifi_client_networks[0].enabled is False
 
 
-async def test_add_derives_wifi_id_and_network_from_existing(rosys_integration):
-    """Adding copies wifi_id/network from an existing client entry and returns the new id."""
-    api = FakeRouterApi([_client('cfg_a', 'Barn', wifi_id='radio1', network='wwan2')])
+async def test_add_appends_with_next_priority(rosys_integration):
+    """Adding posts ssid/key/enabled with the next free priority and returns the new id."""
+    api = FakeMultiApApi([_entry('1', 'Barn', priority='1'), _entry('2', 'Shed', priority='2')])
     router = _make_router(api)
-    network_id = await router.add_wifi_client_network('Field', 'secret', encryption='sae', enabled=True)
-    assert network_id == 'cfg1'
+    await router.refresh_wifi_client_networks()
+    network_id = await router.add_wifi_client_network('Field', 'hunter2', enabled=True)
+    assert network_id == '3'
     post = next(r for r in api.requests if r[0] == 'POST')
-    assert post[2] == {'mode': 'multi_ap', 'ssid': 'Field', 'key': 'secret', 'encryption': 'sae',
-                       'wifi_id': 'radio1', 'network': 'wwan2', 'enabled': '1'}
-    assert {n.ssid for n in router.wifi_client_networks} == {'Barn', 'Field'}
+    assert post[2] == {'ssid': 'Field', 'key': 'hunter2', 'priority': '3', 'enabled': '1'}
+    assert {n.ssid for n in router.wifi_client_networks} == {'Barn', 'Shed', 'Field'}
 
 
-async def test_add_fails_without_template(rosys_integration):
-    """Adding fails (returns None, sends no POST) when no client entry exists to copy from."""
-    api = FakeRouterApi([])
+async def test_add_on_empty_list_uses_priority_one(rosys_integration):
+    """Adding to an empty list assigns priority 1."""
+    api = FakeMultiApApi([])
     router = _make_router(api)
-    assert await router.add_wifi_client_network('Field', 'secret') is None
-    assert not any(r[0] == 'POST' for r in api.requests)
+    await router.refresh_wifi_client_networks()
+    assert await router.add_wifi_client_network('Field', 'hunter2') == '1'
+    post = next(r for r in api.requests if r[0] == 'POST')
+    assert post[2]['priority'] == '1'
 
 
 async def test_remove_deletes_and_refreshes(rosys_integration):
     """Removing deletes the entry and drops it from the cached list."""
-    api = FakeRouterApi([_client('cfg_a', 'Barn'), _client('cfg_b', 'Shed')])
+    api = FakeMultiApApi([_entry('1', 'Barn', priority='1'), _entry('2', 'Shed', priority='2')])
     router = _make_router(api)
-    assert await router.remove_wifi_client_network('cfg_a')
-    assert any(r[0] == 'DELETE' and r[1] == f'{BASE_PATH}/cfg_a' for r in api.requests)
+    assert await router.remove_wifi_client_network('1')
+    assert any(r[0] == 'DELETE' and r[1] == f'{BASE_PATH}/1' for r in api.requests)
     assert [n.ssid for n in router.wifi_client_networks] == ['Shed']
 
 

--- a/tests/test_teltonika_router.py
+++ b/tests/test_teltonika_router.py
@@ -1,0 +1,149 @@
+import json
+
+import httpx
+import rosys
+
+from feldfreund_devkit.hardware.teltonika_router import TeltonikaRouter
+
+BASE_PATH = '/api/wireless/interfaces/config'
+
+
+def _sta(section_id: str, ssid: str, *, enabled: str = '1', **extra: str) -> dict:
+    """Build a raw station-mode interface config entry as the RutOS API returns it.
+
+    :param section_id: the config section id.
+    :param ssid: the network name.
+    :param enabled: the RutOS ``enabled`` flag ('1' or '0').
+    :param extra: additional raw fields to merge in.
+    :return: the raw interface dict.
+    """
+    return {'id': section_id, '.name': section_id, 'mode': 'sta', 'ssid': ssid,
+            'enabled': enabled, 'encryption': 'psk2', 'device': 'radio0', 'network': 'wwan', **extra}
+
+
+class FakeRouterApi:
+    """A stateful RutOS wireless-config endpoint backed by an in-memory interface list."""
+
+    def __init__(self, interfaces: list[dict]) -> None:
+        self.interfaces = interfaces
+        self.requests: list[tuple[str, str, dict | None]] = []
+        self._counter = 0
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        """Serve GET/POST/PUT/DELETE against the in-memory interface list.
+
+        :param request: the intercepted HTTP request.
+        :return: the mocked response.
+        """
+        body = json.loads(request.content)['data'] if request.content else None
+        self.requests.append((request.method, request.url.path, body))
+        path = request.url.path
+        if path == BASE_PATH:
+            if request.method == 'GET':
+                return httpx.Response(200, json={'data': self.interfaces})
+            if request.method == 'POST':
+                self._counter += 1
+                section_id = f'cfg{self._counter}'
+                self.interfaces.append({**body, 'id': section_id, '.name': section_id})
+                return httpx.Response(200, json={'data': {'id': section_id}})
+        if path.startswith(f'{BASE_PATH}/'):
+            section_id = path.rsplit('/', 1)[1]
+            if request.method == 'PUT':
+                for interface in self.interfaces:
+                    if interface.get('id') == section_id:
+                        interface.update(body)
+                return httpx.Response(200, json={'data': {'id': section_id}})
+            if request.method == 'DELETE':
+                self.interfaces = [i for i in self.interfaces if i.get('id') != section_id]
+                return httpx.Response(200, json={'data': {}})
+        return httpx.Response(404, json={'error': 'not found'})
+
+
+def _make_router(api: FakeRouterApi) -> TeltonikaRouter:
+    """Create a router wired to a mocked transport with a pre-seeded auth token.
+
+    :param api: the fake API whose handler backs the mock transport.
+    :return: the ready-to-use router.
+    """
+    router = TeltonikaRouter('http://router/api', 'password')
+    # pylint: disable=protected-access
+    router._client = httpx.AsyncClient(transport=httpx.MockTransport(api.handler),
+                                       headers={'Content-Type': 'application/json'})
+    router._auth_token = 'test-token'
+    router._token_time = rosys.time()
+    return router
+
+
+async def test_refresh_lists_only_station_networks(rosys_integration):
+    """Refreshing keeps only station-mode interfaces and parses their enabled state."""
+    api = FakeRouterApi([
+        _sta('cfg_a', 'Barn', enabled='1'),
+        {'id': 'cfg_ap', 'mode': 'ap', 'ssid': 'RobotAP', 'enabled': '1'},
+        _sta('cfg_b', 'Shed', enabled='0'),
+    ])
+    router = _make_router(api)
+    await router.refresh_wifi_client_networks()
+    networks = router.wifi_client_networks
+    assert [n.ssid for n in networks] == ['Barn', 'Shed']
+    assert [n.enabled for n in networks] == [True, False]
+    assert networks[0].id == 'cfg_a'
+
+
+async def test_refresh_emits_event(rosys_integration):
+    """Refreshing emits WIFI_NETWORKS_CHANGED."""
+    api = FakeRouterApi([_sta('cfg_a', 'Barn')])
+    router = _make_router(api)
+    events = 0
+
+    def on_change() -> None:
+        nonlocal events
+        events += 1
+    router.WIFI_NETWORKS_CHANGED.subscribe(on_change)
+    await router.refresh_wifi_client_networks()
+    assert events == 1
+
+
+async def test_set_enabled_sends_put_and_refreshes(rosys_integration):
+    """Toggling sends a PUT with the enabled flag and refreshes the cached list."""
+    api = FakeRouterApi([_sta('cfg_a', 'Barn', enabled='1')])
+    router = _make_router(api)
+    assert await router.set_wifi_client_enabled('cfg_a', False)
+    put_requests = [r for r in api.requests if r[0] == 'PUT']
+    assert put_requests == [('PUT', f'{BASE_PATH}/cfg_a', {'enabled': '0'})]
+    assert router.wifi_client_networks[0].enabled is False
+
+
+async def test_add_derives_device_and_network_from_existing(rosys_integration):
+    """Adding copies device/network from an existing station entry and returns the new id."""
+    api = FakeRouterApi([_sta('cfg_a', 'Barn', device='radio1', network='wwan2')])
+    router = _make_router(api)
+    network_id = await router.add_wifi_client_network('Field', 'secret', encryption='sae', enabled=True)
+    assert network_id == 'cfg1'
+    post = next(r for r in api.requests if r[0] == 'POST')
+    assert post[2] == {'mode': 'sta', 'ssid': 'Field', 'key': 'secret', 'encryption': 'sae',
+                       'device': 'radio1', 'network': 'wwan2', 'enabled': '1'}
+    assert {n.ssid for n in router.wifi_client_networks} == {'Barn', 'Field'}
+
+
+async def test_add_fails_without_template(rosys_integration):
+    """Adding fails (returns None, sends no POST) when no station entry exists to copy from."""
+    api = FakeRouterApi([])
+    router = _make_router(api)
+    assert await router.add_wifi_client_network('Field', 'secret') is None
+    assert not any(r[0] == 'POST' for r in api.requests)
+
+
+async def test_remove_deletes_and_refreshes(rosys_integration):
+    """Removing deletes the entry and drops it from the cached list."""
+    api = FakeRouterApi([_sta('cfg_a', 'Barn'), _sta('cfg_b', 'Shed')])
+    router = _make_router(api)
+    assert await router.remove_wifi_client_network('cfg_a')
+    assert any(r[0] == 'DELETE' and r[1] == f'{BASE_PATH}/cfg_a' for r in api.requests)
+    assert [n.ssid for n in router.wifi_client_networks] == ['Shed']
+
+
+def test_parse_falls_back_to_disabled_field():
+    """When only the UCI 'disabled' flag is present, enabled is its inverse."""
+    # pylint: disable=protected-access
+    assert TeltonikaRouter._parse_wifi_client({'id': 'x', 'ssid': 'A', 'disabled': '0'}).enabled is True
+    assert TeltonikaRouter._parse_wifi_client({'id': 'x', 'ssid': 'A', 'disabled': '1'}).enabled is False

--- a/tests/test_teltonika_router.py
+++ b/tests/test_teltonika_router.py
@@ -114,12 +114,11 @@ async def test_set_enabled_sends_put_and_refreshes(rosys_integration):
 
 
 async def test_add_appends_with_next_priority(rosys_integration):
-    """Adding posts ssid/key/enabled with the next free priority and returns the new id."""
+    """Adding posts ssid/key/enabled with the next free priority and reports success."""
     api = FakeMultiApApi([_entry('1', 'Barn', priority='1'), _entry('2', 'Shed', priority='2')])
     router = _make_router(api)
     await router.refresh_wifi_client_networks()
-    network_id = await router.add_wifi_client_network('Field', 'hunter2', enabled=True)
-    assert network_id == '3'
+    assert await router.add_wifi_client_network('Field', 'hunter2', enabled=True) is True
     post = next(r for r in api.requests if r[0] == 'POST')
     assert post[2] == {'ssid': 'Field', 'key': 'hunter2', 'priority': '3', 'enabled': '1'}
     assert {n.ssid for n in router.wifi_client_networks} == {'Barn', 'Shed', 'Field'}
@@ -130,7 +129,7 @@ async def test_add_on_empty_list_uses_priority_one(rosys_integration):
     api = FakeMultiApApi([])
     router = _make_router(api)
     await router.refresh_wifi_client_networks()
-    assert await router.add_wifi_client_network('Field', 'hunter2') == '1'
+    assert await router.add_wifi_client_network('Field', 'hunter2') is True
     post = next(r for r in api.requests if r[0] == 'POST')
     assert post[2]['priority'] == '1'
 

--- a/tests/test_teltonika_router.py
+++ b/tests/test_teltonika_router.py
@@ -8,8 +8,8 @@ from feldfreund_devkit.hardware.teltonika_router import TeltonikaRouter
 BASE_PATH = '/api/wireless/interfaces/config'
 
 
-def _sta(section_id: str, ssid: str, *, enabled: str = '1', **extra: str) -> dict:
-    """Build a raw station-mode interface config entry as the RutOS API returns it.
+def _client(section_id: str, ssid: str, *, enabled: str = '1', **extra: str) -> dict:
+    """Build a raw upstream-client interface config entry as the RutOS API returns it.
 
     :param section_id: the config section id.
     :param ssid: the network name.
@@ -17,8 +17,8 @@ def _sta(section_id: str, ssid: str, *, enabled: str = '1', **extra: str) -> dic
     :param extra: additional raw fields to merge in.
     :return: the raw interface dict.
     """
-    return {'id': section_id, '.name': section_id, 'mode': 'sta', 'ssid': ssid,
-            'enabled': enabled, 'encryption': 'psk2', 'device': 'radio0', 'network': 'wwan', **extra}
+    return {'id': section_id, 'mode': 'multi_ap', 'ssid': ssid, 'enabled': enabled,
+            'encryption': 'psk2', 'wifi_id': 'radio0', 'network': 'wwan', **extra}
 
 
 class FakeRouterApi:
@@ -74,12 +74,12 @@ def _make_router(api: FakeRouterApi) -> TeltonikaRouter:
     return router
 
 
-async def test_refresh_lists_only_station_networks(rosys_integration):
-    """Refreshing keeps only station-mode interfaces and parses their enabled state."""
+async def test_refresh_lists_only_client_networks(rosys_integration):
+    """Refreshing keeps only upstream-client interfaces and parses their enabled state."""
     api = FakeRouterApi([
-        _sta('cfg_a', 'Barn', enabled='1'),
+        _client('cfg_a', 'Barn', enabled='1'),
         {'id': 'cfg_ap', 'mode': 'ap', 'ssid': 'RobotAP', 'enabled': '1'},
-        _sta('cfg_b', 'Shed', enabled='0'),
+        _client('cfg_b', 'Shed', enabled='0'),
     ])
     router = _make_router(api)
     await router.refresh_wifi_client_networks()
@@ -91,7 +91,7 @@ async def test_refresh_lists_only_station_networks(rosys_integration):
 
 async def test_refresh_emits_event(rosys_integration):
     """Refreshing emits WIFI_NETWORKS_CHANGED."""
-    api = FakeRouterApi([_sta('cfg_a', 'Barn')])
+    api = FakeRouterApi([_client('cfg_a', 'Barn')])
     router = _make_router(api)
     events = 0
 
@@ -105,7 +105,7 @@ async def test_refresh_emits_event(rosys_integration):
 
 async def test_set_enabled_sends_put_and_refreshes(rosys_integration):
     """Toggling sends a PUT with the enabled flag and refreshes the cached list."""
-    api = FakeRouterApi([_sta('cfg_a', 'Barn', enabled='1')])
+    api = FakeRouterApi([_client('cfg_a', 'Barn', enabled='1')])
     router = _make_router(api)
     assert await router.set_wifi_client_enabled('cfg_a', False)
     put_requests = [r for r in api.requests if r[0] == 'PUT']
@@ -113,20 +113,20 @@ async def test_set_enabled_sends_put_and_refreshes(rosys_integration):
     assert router.wifi_client_networks[0].enabled is False
 
 
-async def test_add_derives_device_and_network_from_existing(rosys_integration):
-    """Adding copies device/network from an existing station entry and returns the new id."""
-    api = FakeRouterApi([_sta('cfg_a', 'Barn', device='radio1', network='wwan2')])
+async def test_add_derives_wifi_id_and_network_from_existing(rosys_integration):
+    """Adding copies wifi_id/network from an existing client entry and returns the new id."""
+    api = FakeRouterApi([_client('cfg_a', 'Barn', wifi_id='radio1', network='wwan2')])
     router = _make_router(api)
     network_id = await router.add_wifi_client_network('Field', 'secret', encryption='sae', enabled=True)
     assert network_id == 'cfg1'
     post = next(r for r in api.requests if r[0] == 'POST')
-    assert post[2] == {'mode': 'sta', 'ssid': 'Field', 'key': 'secret', 'encryption': 'sae',
-                       'device': 'radio1', 'network': 'wwan2', 'enabled': '1'}
+    assert post[2] == {'mode': 'multi_ap', 'ssid': 'Field', 'key': 'secret', 'encryption': 'sae',
+                       'wifi_id': 'radio1', 'network': 'wwan2', 'enabled': '1'}
     assert {n.ssid for n in router.wifi_client_networks} == {'Barn', 'Field'}
 
 
 async def test_add_fails_without_template(rosys_integration):
-    """Adding fails (returns None, sends no POST) when no station entry exists to copy from."""
+    """Adding fails (returns None, sends no POST) when no client entry exists to copy from."""
     api = FakeRouterApi([])
     router = _make_router(api)
     assert await router.add_wifi_client_network('Field', 'secret') is None
@@ -135,7 +135,7 @@ async def test_add_fails_without_template(rosys_integration):
 
 async def test_remove_deletes_and_refreshes(rosys_integration):
     """Removing deletes the entry and drops it from the cached list."""
-    api = FakeRouterApi([_sta('cfg_a', 'Barn'), _sta('cfg_b', 'Shed')])
+    api = FakeRouterApi([_client('cfg_a', 'Barn'), _client('cfg_b', 'Shed')])
     router = _make_router(api)
     assert await router.remove_wifi_client_network('cfg_a')
     assert any(r[0] == 'DELETE' and r[1] == f'{BASE_PATH}/cfg_a' for r in api.requests)


### PR DESCRIPTION
### Motivation

We need to manage the router's MultiAP upstream WiFi networks from the app — list the candidate SSIDs, add and remove them, and switch each one active/inactive.

### Implementation

- Add CRUD over the RutOS `wireless/multi_ap/config` endpoint (the MultiAP candidate AP list, one section per SSID with `id`/`ssid`/`key`/`enabled`/`priority`) to `TeltonikaRouter` (`_request` gains PUT/DELETE): `refresh_wifi_client_networks` (sorted by priority), `add_wifi_client_network` (appends with the next free priority), `remove_wifi_client_network`, `set_wifi_client_enabled`, plus a `wifi_client_networks` property and `WifiClientNetwork` dataclass.
- Fetch the list once `on_startup`; no polling. Mutations refresh it and emit the new `WIFI_NETWORKS_CHANGED` event.
- Refactor the Teltonika panel into an expansion group and add a `WiFi Networks` expansion (refresh button, per-network enable switch, delete, add dialog). Enable changes and deletes are gated behind the shared `ConfirmDialog`.
- Build the detail expansions once (only their content refreshes) so a periodic update no longer collapses an open one, and persist each expansion's open state in `app.storage.user` (same convention as `operation.py`).

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] I documented breaking changes and set the 'breaking change' label if needed
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
  - [x] Endpoint + list confirmed on hardware (`wireless/multi_ap/config`; `enabled` is `0`/`1`).
  - [x] Verify add / enable-disable / delete actually write on the device.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

---
⬛ claude-opus-4-8[1m]