### PR TITLE
Show the robot ID in the header bar and page title

### DIFF
--- a/feldfreund_devkit/interface/components/header_bar.py
+++ b/feldfreund_devkit/interface/components/header_bar.py
@@ -24,7 +24,7 @@ class HeaderBar:
     def content(self) -> None:
         ui.colors(primary='#6E93D6', secondary='#53B689', accent='#111B1E', positive='#53B689')
         if self.robot_id:
-            ui.page_title(f'{self.robot_id} · Feldfreund')
+            ui.page_title(f'Feldfreund {self.robot_id}')
         with ui.header().classes('items-center py-3'):
             with ui.link(target='/'):
                 ui.image('assets/zz_logo.png').classes('w-12')

--- a/feldfreund_devkit/interface/components/header_bar.py
+++ b/feldfreund_devkit/interface/components/header_bar.py
@@ -9,11 +9,13 @@ class HeaderBar:
     """Navigation header with logo, page links, and status indicators."""
 
     def __init__(self, pages: dict[str, str] | None = None, *,
+                 robot_id: str | None = None,
                  estop: EStop | None = None,
                  bms: Bms | None = None,
                  bms_url: str | None = None,
                  teltonika_router: TeltonikaRouter | None = None):
         self._pages = pages or {}
+        self.robot_id = robot_id.upper() if robot_id else None
         self.estop = estop
         self.bms = bms
         self.bms_url = bms_url
@@ -21,10 +23,13 @@ class HeaderBar:
 
     def content(self) -> None:
         ui.colors(primary='#6E93D6', secondary='#53B689', accent='#111B1E', positive='#53B689')
+        if self.robot_id:
+            ui.page_title(f'{self.robot_id} · Feldfreund')
         with ui.header().classes('items-center py-3'):
             with ui.link(target='/'):
                 ui.image('assets/zz_logo.png').classes('w-12')
-            ui.link('FELDFREUND', '/').classes('text-2xl text-white !no-underline mr-auto')
+            title = f'FELDFREUND {self.robot_id}' if self.robot_id else 'FELDFREUND'
+            ui.link(title, '/').classes('text-2xl text-white !no-underline mr-auto')
             with ui.row().classes('items-right pr-4'):
                 if self.estop:
                     self.estop_status(self.estop)


### PR DESCRIPTION
### Motivation

On the field with several robots it is hard to tell which robot a browser tab is actually connected to. Surfacing the robot ID in the header and the tab title makes this obvious at a glance.

### Implementation

- Add an optional `robot_id` parameter to `HeaderBar`
- Render `FELDFREUND <ID>` in the header link (falls back to `FELDFREUND` when no ID is given)
- Set the page title to `Feldfreund <ID>` via `ui.page_title` so the browser tab is distinguishable

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary). — presentational change, no UI test harness exists in this repo
- [x] Documentation has been added (or is not necessary).

---
⬛ claude-opus-4-8 (1M context)