### PR TITLE
Fix docs deploy on tagged releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,7 @@ jobs:
   docs:
     name: Build and publish docs
     runs-on: ubuntu-latest
-    needs: pypi
+    needs: test
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ __pycache__
 # NiceGUI specific
 .nicegui/
 temp*.py
+
+# generated docs
+site/

--- a/docs/generate_reference.py
+++ b/docs/generate_reference.py
@@ -18,6 +18,8 @@ def extract_events(filepath: str) -> dict[str, str]:
     for i, line in enumerate(lines):
         if re.search(r'= Event(\[.*?\])?\(\)$', line):
             event_name_ = line.strip().split()[0].removeprefix('self.').rstrip(':')
+            if i + 1 >= len(lines) or '"""' not in lines[i + 1]:
+                continue
             event_doc_ = lines[i + 1].split('"""')[1]
             events_[event_name_] = event_doc_
     return events_


### PR DESCRIPTION
### Motivation

The v0.2.0 tag revealed two problems in the release pipeline: the docs job crashed in `generate_reference.py`, and it would not have run anyway because it depends on the PyPI publish, which currently fails (PyPI rejects the git-pinned rosys dependency). The v0.2.0 docs were deployed manually; this makes future deploys work again.

### Implementation

- Fix `extract_events` crashing on `Event` declarations without a docstring on the following line (five such events exist in devkit and rosys sources); skip them instead, mirroring the guard in `extract_instance_attributes`
- Run the `docs` job after `test` instead of after `pypi`, so documentation deploys even when the PyPI publish fails
- Ignore the locally generated `site/` folder

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] I documented breaking changes and set the 'breaking change' label if needed
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

---
⬛ claude-fable-5