### PR TITLE
Stop rebuilding the ODrive tracks developer UI on every update interval

### DIFF
--- a/feldfreund_devkit/hardware/tracks.py
+++ b/feldfreund_devkit/hardware/tracks.py
@@ -131,24 +131,20 @@ class ODriveTracksHardware(TracksHardware):
                 rosys.notify('Motor Error', 'negative')
 
     def developer_ui(self) -> None:
-        @ui.refreshable
-        def _ui() -> None:
-            ui.label('ODrive Tracks').classes('text-center text-bold')
-            if self.config.odrive_version == self.ERROR_FLAG_VERSION:
-                with ui.grid(columns=2).classes('gap-0'):
-                    ui.label(f'L0: {"Error" if self._l0_error else "No error"}')
-                    ui.label(f'L1: {"Error" if self._l1_error else "No error"}')
-                    ui.label(f'R0: {"Error" if self._r0_error else "No error"}')
-                    ui.label(f'R1: {"Error" if self._r1_error else "No error"}')
-                ui.button('Reset motor errors', on_click=self.reset_motors).set_enabled(self.motor_error)
-            if self.config.has_temperature_sensor:
-                with ui.grid(columns=2).classes('gap-0'):
-                    ui.label(f'L0: {self._l0_temperature:.1f}°C')
-                    ui.label(f'L1: {self._l1_temperature:.1f}°C')
-                    ui.label(f'R0: {self._r0_temperature:.1f}°C')
-                    ui.label(f'R1: {self._r1_temperature:.1f}°C')
-        _ui()
-        ui.timer(rosys.config.ui_update_interval, _ui.refresh)
+        ui.label('ODrive Tracks').classes('text-center text-bold')
+        if self.config.odrive_version == self.ERROR_FLAG_VERSION:
+            with ui.grid(columns=2).classes('gap-0'):
+                ui.label().bind_text_from(self, '_l0_error', lambda error: f'L0: {"Error" if error else "No error"}')
+                ui.label().bind_text_from(self, '_l1_error', lambda error: f'L1: {"Error" if error else "No error"}')
+                ui.label().bind_text_from(self, '_r0_error', lambda error: f'R0: {"Error" if error else "No error"}')
+                ui.label().bind_text_from(self, '_r1_error', lambda error: f'R1: {"Error" if error else "No error"}')
+            ui.button('Reset motor errors', on_click=self.reset_motors).bind_enabled_from(self, 'motor_error')
+        if self.config.has_temperature_sensor:
+            with ui.grid(columns=2).classes('gap-0'):
+                ui.label().bind_text_from(self, '_l0_temperature', lambda temperature: f'L0: {temperature:.1f}°C')
+                ui.label().bind_text_from(self, '_l1_temperature', lambda temperature: f'L1: {temperature:.1f}°C')
+                ui.label().bind_text_from(self, '_r0_temperature', lambda temperature: f'R0: {temperature:.1f}°C')
+                ui.label().bind_text_from(self, '_r1_temperature', lambda temperature: f'R1: {temperature:.1f}°C')
 
 
 class TracksSimulation(WheelsSimulation):  # pylint: disable=too-many-ancestors


### PR DESCRIPTION
### Motivation

The ODrive tracks developer UI rebuilt its whole section — including the 'Reset motor errors' button — on every UI update interval, so the button never lived longer than one tick and its enabled state was only evaluated at build time.

### Implementation

- Replace the `ui.refreshable` and its `ui.timer` in `ODriveTracksHardware.developer_ui` with bindings
- Bind the error and temperature labels via `bind_text_from` and the reset button's enabled state via `bind_enabled_from(self, 'motor_error')`

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] I documented breaking changes and set the 'breaking change' label if needed
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

---
⬛ claude-fable-5
