### PR TITLE
Add an auto-connect setting for cameras

### DIFF
--- a/feldfreund_devkit/camera_provider.py
+++ b/feldfreund_devkit/camera_provider.py
@@ -4,7 +4,7 @@ import logging
 from typing import Literal
 
 import rosys
-from nicegui import events, ui
+from nicegui import ui
 from rosys.geometry import FrameProvider, Pose3d, Rotation
 from rosys.vision import CalibratableCamera
 from rosys.vision.mjpeg_camera.vendors import VendorType as MjpegVendorType
@@ -65,7 +65,7 @@ class CameraProvider:
         """
         self.log = logging.getLogger('feldfreund.camera_provider')
         self._config = config
-        self._auto_connect: dict[str, bool] = {}
+        self._should_be_connected: dict[str, bool] = {}
         self.mains: list[rosys.vision.CalibratableCamera] = self._setup_mains()
         self.front = self._setup('front')
         self.back = self._setup('back')
@@ -130,14 +130,14 @@ class CameraProvider:
         return {k: v for k, v in slots.items() if v is not None}
 
     @property
-    def auto_connect(self) -> dict[str, bool]:
-        """Desired connection state per camera id, initialized from the slot configurations.
+    def should_be_connected(self) -> dict[str, bool]:
+        """Whether each camera is supposed to be connected, initialized from the slot configurations.
 
-        The returned dictionary is a copy; use ``set_auto_connect`` to change a state so that the
+        The returned dictionary is a copy; use ``set_connected`` to change a state so that the
         camera is connected or disconnected accordingly. The state is runtime-only: it is not
         persisted and falls back to the configuration on restart.
         """
-        return dict(self._auto_connect)
+        return dict(self._should_be_connected)
 
     def set_frame_provider(self, frame_provider: FrameProvider) -> None:
         """Link all calibrated cameras to the given frame provider."""
@@ -146,18 +146,18 @@ class CameraProvider:
                 continue
             camera.calibration.extrinsics.in_frame(frame_provider.frame)
 
-    async def set_auto_connect(self, camera_id: str, enabled: bool) -> None:
-        """Set the desired connection state of a camera and apply it immediately.
+    async def set_connected(self, camera_id: str, connected: bool) -> None:
+        """Connect or disconnect a camera and remember that this is how it should stay.
 
-        :param camera_id: Id of the camera to change.
-        :param enabled: Whether the camera should be connected and kept connected.
+        :param camera_id: Id of the camera to connect or disconnect.
+        :param connected: Whether the camera should be connected.
         :raises ValueError: If no camera with the given id is configured.
         """
         if camera_id not in self._cameras:
             raise ValueError(f'Unknown camera id: {camera_id} (available: {", ".join(sorted(self._cameras))})')
-        self._auto_connect[camera_id] = enabled
+        self._should_be_connected[camera_id] = connected
         camera = self._cameras[camera_id]
-        if enabled:
+        if connected:
             await camera.connect()
         else:
             await camera.disconnect()
@@ -176,7 +176,7 @@ class CameraProvider:
         camera = self._create_camera(slot_config)
         if slot_config.calibration is not None:
             camera.calibration = slot_config.calibration
-        self._auto_connect[camera.id] = slot_config.auto_connect
+        self._should_be_connected[camera.id] = slot_config.auto_connect
         return camera
 
     def _create_camera(self, slot: CameraSlotConfig) -> rosys.vision.CalibratableCamera:
@@ -209,7 +209,7 @@ class CameraProvider:
     async def update_device_list(self) -> None:
         """Attempt to connect all disconnected cameras that are supposed to be connected."""
         for camera in self.cameras.values():
-            if camera.is_connected or not self._auto_connect[camera.id]:
+            if camera.is_connected or not self._should_be_connected[camera.id]:
                 continue
             try:
                 await camera.connect()
@@ -263,10 +263,9 @@ class CameraProvider:
         ])
         with ui.column():
             ui.label('Cameras').classes('text-center text-bold')
-            with ui.grid(columns='auto auto auto auto auto').classes('items-center'):
+            with ui.grid(columns='auto auto auto auto').classes('items-center'):
                 ui.label('Slot').classes('font-bold')
                 ui.label('Connected').classes('font-bold')
-                ui.label('Auto-connect').classes('font-bold')
                 ui.label('Resolution').classes('font-bold')
                 ui.label('Type').classes('font-bold')
                 for name, camera, slot_cfg in slots:
@@ -275,24 +274,10 @@ class CameraProvider:
                         status_bulb()
                         ui.label('—').classes('text-center')
                         ui.label('—').classes('text-center')
-                        ui.label('—').classes('text-center')
                     else:
-                        current_camera_id = camera.id
-                        status_bulb().bind_value_from(camera, 'is_connected')
-
-                        async def toggle_auto_connect(event: events.ValueChangeEventArguments,
-                                                      camera_id: str = current_camera_id) -> None:
-                            if event.value == self._auto_connect[camera_id]:
-                                return  # the binding pushed a state that is already applied
-                            try:
-                                await self.set_auto_connect(camera_id, event.value)
-                            except Exception as error:
-                                action = 'connect' if event.value else 'disconnect'
-                                self.log.warning('Failed to %s camera %s', action, camera_id, exc_info=True)
-                                rosys.notify(f'Failed to {action} camera {camera_id}: {error}', 'negative')
-
-                        ui.switch(value=self._auto_connect[current_camera_id], on_change=toggle_auto_connect) \
-                            .bind_value_from(self._auto_connect, current_camera_id)
+                        with ui.row().classes('items-center gap-1'):
+                            status_bulb().bind_value_from(camera, 'is_connected')
+                            self._connection_button(camera.id)
                         resolution = ui.label('—')
 
                         def update_resolution(label: ui.label = resolution, cam: rosys.vision.CalibratableCamera | None = camera) -> None:
@@ -304,3 +289,26 @@ class CameraProvider:
                         ui.timer(5.0, update_resolution)
                         ui.label(self._camera_config_name(slot_cfg))
             ui.button('Scan for cameras', on_click=self.scan)
+
+    def _connection_button(self, camera_id: str) -> None:
+        """Add a button that connects or disconnects a camera, labeled with the action it offers.
+
+        The icon shows what a click does, so the camera's desired state stays visible next to the
+        status bulb: a button offering "Disconnect" on a grey bulb means the connection is failing.
+
+        :param camera_id: Id of the camera to connect or disconnect.
+        """
+        async def toggle() -> None:
+            connected = not self._should_be_connected[camera_id]
+            try:
+                await self.set_connected(camera_id, connected)
+            except Exception as error:
+                action = 'connect' if connected else 'disconnect'
+                self.log.warning('Failed to %s camera %s', action, camera_id, exc_info=True)
+                rosys.notify(f'Failed to {action} camera {camera_id}: {error}', 'negative')
+
+        with ui.button(on_click=toggle).props('flat dense round size=sm') \
+                .bind_icon_from(self._should_be_connected, camera_id,
+                                backward=lambda connected: 'link_off' if connected else 'link'):
+            ui.tooltip().bind_text_from(self._should_be_connected, camera_id,
+                                        backward=lambda connected: 'Disconnect' if connected else 'Connect')

--- a/feldfreund_devkit/camera_provider.py
+++ b/feldfreund_devkit/camera_provider.py
@@ -133,9 +133,11 @@ class CameraProvider:
     def auto_connect(self) -> dict[str, bool]:
         """Desired connection state per camera id, initialized from the slot configurations.
 
-        The state is runtime-only: it is not persisted and falls back to the configuration on restart.
+        The returned dictionary is a copy; use ``set_auto_connect`` to change a state so that the
+        camera is connected or disconnected accordingly. The state is runtime-only: it is not
+        persisted and falls back to the configuration on restart.
         """
-        return self._auto_connect
+        return dict(self._auto_connect)
 
     def set_frame_provider(self, frame_provider: FrameProvider) -> None:
         """Link all calibrated cameras to the given frame provider."""
@@ -280,9 +282,17 @@ class CameraProvider:
 
                         async def toggle_auto_connect(event: events.ValueChangeEventArguments,
                                                       camera_id: str = current_camera_id) -> None:
-                            await self.set_auto_connect(camera_id, event.value)
+                            if event.value == self._auto_connect[camera_id]:
+                                return  # the binding pushed a state that is already applied
+                            try:
+                                await self.set_auto_connect(camera_id, event.value)
+                            except Exception as error:
+                                action = 'connect' if event.value else 'disconnect'
+                                self.log.warning('Failed to %s camera %s', action, camera_id, exc_info=True)
+                                rosys.notify(f'Failed to {action} camera {camera_id}: {error}', 'negative')
 
-                        ui.switch(value=self._auto_connect[current_camera_id], on_change=toggle_auto_connect)
+                        ui.switch(value=self._auto_connect[current_camera_id], on_change=toggle_auto_connect) \
+                            .bind_value_from(self._auto_connect, current_camera_id)
                         resolution = ui.label('—')
 
                         def update_resolution(label: ui.label = resolution, cam: rosys.vision.CalibratableCamera | None = camera) -> None:

--- a/feldfreund_devkit/camera_provider.py
+++ b/feldfreund_devkit/camera_provider.py
@@ -4,7 +4,7 @@ import logging
 from typing import Literal
 
 import rosys
-from nicegui import ui
+from nicegui import events, ui
 from rosys.geometry import FrameProvider, Pose3d, Rotation
 from rosys.vision import CalibratableCamera
 from rosys.vision.mjpeg_camera.vendors import VendorType as MjpegVendorType
@@ -65,6 +65,7 @@ class CameraProvider:
         """
         self.log = logging.getLogger('feldfreund.camera_provider')
         self._config = config
+        self._auto_connect: dict[str, bool] = {}
         self.mains: list[rosys.vision.CalibratableCamera] = self._setup_mains()
         self.front = self._setup('front')
         self.back = self._setup('back')
@@ -128,12 +129,36 @@ class CameraProvider:
         slots = {'front': self.front, 'back': self.back, 'left': self.left, 'right': self.right}
         return {k: v for k, v in slots.items() if v is not None}
 
+    @property
+    def auto_connect(self) -> dict[str, bool]:
+        """Desired connection state per camera id, initialized from the slot configurations.
+
+        The state is runtime-only: it is not persisted and falls back to the configuration on restart.
+        """
+        return self._auto_connect
+
     def set_frame_provider(self, frame_provider: FrameProvider) -> None:
         """Link all calibrated cameras to the given frame provider."""
         for camera in self.cameras.values():
             if camera.calibration is None:
                 continue
             camera.calibration.extrinsics.in_frame(frame_provider.frame)
+
+    async def set_auto_connect(self, camera_id: str, enabled: bool) -> None:
+        """Set the desired connection state of a camera and apply it immediately.
+
+        :param camera_id: Id of the camera to change.
+        :param enabled: Whether the camera should be connected and kept connected.
+        :raises ValueError: If no camera with the given id is configured.
+        """
+        if camera_id not in self._cameras:
+            raise ValueError(f'Unknown camera id: {camera_id} (available: {", ".join(sorted(self._cameras))})')
+        self._auto_connect[camera_id] = enabled
+        camera = self._cameras[camera_id]
+        if enabled:
+            await camera.connect()
+        else:
+            await camera.disconnect()
 
     def _setup(self, name: CameraPosition) -> rosys.vision.CalibratableCamera | None:
         """Create a camera for the given position, and apply calibration if available."""
@@ -149,6 +174,7 @@ class CameraProvider:
         camera = self._create_camera(slot_config)
         if slot_config.calibration is not None:
             camera.calibration = slot_config.calibration
+        self._auto_connect[camera.id] = slot_config.auto_connect
         return camera
 
     def _create_camera(self, slot: CameraSlotConfig) -> rosys.vision.CalibratableCamera:
@@ -161,6 +187,7 @@ class CameraProvider:
                 height=slot.height,
                 fps=slot.fps,
                 color='#cccccc',
+                connect_after_init=slot.auto_connect,
             )
         elif isinstance(slot, UsbCameraConfig):
             camera = CalibratableUsbCamera(**slot.camera_kwargs)
@@ -178,9 +205,9 @@ class CameraProvider:
         return type(config).__name__.removesuffix('CameraConfig').title() if config else 'Unknown'
 
     async def update_device_list(self) -> None:
-        """Attempt to connect to all disconnected cameras."""
+        """Attempt to connect all disconnected cameras that are supposed to be connected."""
         for camera in self.cameras.values():
-            if camera.is_connected:
+            if camera.is_connected or not self._auto_connect[camera.id]:
                 continue
             try:
                 await camera.connect()
@@ -234,9 +261,10 @@ class CameraProvider:
         ])
         with ui.column():
             ui.label('Cameras').classes('text-center text-bold')
-            with ui.grid(columns='auto auto auto auto').classes('items-center'):
+            with ui.grid(columns='auto auto auto auto auto').classes('items-center'):
                 ui.label('Slot').classes('font-bold')
                 ui.label('Connected').classes('font-bold')
+                ui.label('Auto-connect').classes('font-bold')
                 ui.label('Resolution').classes('font-bold')
                 ui.label('Type').classes('font-bold')
                 for name, camera, slot_cfg in slots:
@@ -245,8 +273,16 @@ class CameraProvider:
                         status_bulb()
                         ui.label('—').classes('text-center')
                         ui.label('—').classes('text-center')
+                        ui.label('—').classes('text-center')
                     else:
+                        current_camera_id = camera.id
                         status_bulb().bind_value_from(camera, 'is_connected')
+
+                        async def toggle_auto_connect(event: events.ValueChangeEventArguments,
+                                                      camera_id: str = current_camera_id) -> None:
+                            await self.set_auto_connect(camera_id, event.value)
+
+                        ui.switch(value=self._auto_connect[current_camera_id], on_change=toggle_auto_connect)
                         resolution = ui.label('—')
 
                         def update_resolution(label: ui.label = resolution, cam: rosys.vision.CalibratableCamera | None = camera) -> None:

--- a/feldfreund_devkit/config/camera_configuration.py
+++ b/feldfreund_devkit/config/camera_configuration.py
@@ -45,12 +45,16 @@ class CameraSlotConfig:
 
     rotation and crop are only applied for display purposes and do not affect the actual captured images.
 
+    ``auto_connect`` set to ``False`` keeps the camera disconnected until the connection is
+    requested explicitly, for example with the switch in the camera developer UI.
+
     Defaults:
         fps: 10
         rotation: ImageRotation.NONE
         crop: None
         calibration: None
         image_size: None
+        auto_connect: True
     """
     camera_id: str
     fps: int = 10
@@ -58,6 +62,7 @@ class CameraSlotConfig:
     crop: Rectangle | None = None
     calibration: Calibration | None = None
     image_size: ImageSize | None = None
+    auto_connect: bool = True
 
     def __post_init__(self) -> None:
         if self.calibration is None and self.image_size is None:
@@ -65,7 +70,7 @@ class CameraSlotConfig:
 
     @property
     def camera_kwargs(self) -> dict:
-        return {'id': self.camera_id, 'fps': self.fps}
+        return {'id': self.camera_id, 'fps': self.fps, 'connect_after_init': self.auto_connect}
 
     @property
     def width(self) -> int:

--- a/tests/test_camera_provider.py
+++ b/tests/test_camera_provider.py
@@ -1,7 +1,5 @@
 import pytest
 import rosys
-from nicegui import Client, binding, ui
-from nicegui.page import page
 from rosys.geometry import Rectangle
 from rosys.hardware import WheelsSimulation
 from rosys.testing import forward
@@ -191,71 +189,6 @@ async def test_disabling_auto_connect_disconnects_camera_for_good(robot_locator)
     assert not provider.cameras['usb-0'].is_connected
     await forward(provider.RECONNECT_INTERVAL + 1)
     assert not provider.cameras['usb-0'].is_connected
-
-
-async def test_set_auto_connect_with_unknown_camera_id_raises(robot_locator):
-    """Setting the desired state of an unconfigured camera reports the available ids."""
-    provider = _create_provider(robot_locator, auto_connect=True)
-    with pytest.raises(ValueError, match='Unknown camera id: usb-9'):
-        await provider.set_auto_connect('usb-9', True)
-
-
-async def test_auto_connect_property_returns_a_copy(robot_locator):
-    """The exposed desired-state map must not allow changing a state without connecting or disconnecting."""
-    provider = _create_provider(robot_locator, auto_connect=False)
-    provider.auto_connect['usb-0'] = True
-    assert provider.auto_connect == {'usb-0': False}
-    await forward(provider.RECONNECT_INTERVAL + 1)
-    assert not provider.cameras['usb-0'].is_connected
-
-
-async def test_developer_ui_switch_follows_state_changed_elsewhere(robot_locator):
-    """The switch shows the current desired state even when it is changed outside the UI, e.g. via MCP."""
-    provider = _create_provider(robot_locator, auto_connect=False)
-    with Client(page('/')) as client:
-        provider.developer_ui()
-        switch = _find_switch(client)
-        assert switch.value is False
-        await provider.set_auto_connect('usb-0', True)
-        binding._refresh_step()  # pylint: disable=protected-access
-        assert switch.value is True
-
-
-async def test_developer_ui_switch_notifies_about_a_failing_connect(robot_locator, monkeypatch):
-    """A camera that refuses to connect must tell the operator instead of only writing to the log."""
-    provider = _create_provider(robot_locator, auto_connect=False)
-
-    async def refuse_connection() -> None:
-        raise RuntimeError('device is busy')
-
-    monkeypatch.setattr(provider.cameras['usb-0'], 'connect', refuse_connection)
-    notifications: list[str] = []
-    monkeypatch.setattr(rosys, 'notify', lambda message, *args, **kwargs: notifications.append(message))
-    with Client(page('/')) as client:
-        provider.developer_ui()
-        _find_switch(client).set_value(True)
-        await forward(1)
-    assert notifications == ['Failed to connect camera usb-0: device is busy']
-    assert not provider.cameras['usb-0'].is_connected
-
-
-@pytest.mark.parametrize('auto_connect', [True, False])
-async def test_camera_kwargs_pass_auto_connect_to_rosys(auto_connect: bool):
-    """The auto_connect configuration reaches the rosys camera as its connect_after_init argument."""
-    config = UsbCameraConfig(camera_id='usb-0', image_size=ImageSize(width=1280, height=720),
-                             auto_connect=auto_connect)
-    assert config.camera_kwargs['connect_after_init'] is auto_connect
-
-
-def _find_switch(client: Client) -> ui.switch:
-    """Get the single auto-connect switch of a developer UI built into the given client.
-
-    :param client: Client the developer UI was built into.
-    :return: The auto-connect switch.
-    """
-    switches = [element for element in client.elements.values() if isinstance(element, ui.switch)]
-    assert len(switches) == 1
-    return switches[0]
 
 
 def _create_provider(robot_locator: RobotLocator, *, auto_connect: bool) -> CameraProvider:

--- a/tests/test_camera_provider.py
+++ b/tests/test_camera_provider.py
@@ -164,28 +164,28 @@ async def test_camera_without_auto_connect_stays_disconnected(robot_locator):
     """A camera configured with auto_connect=False is created but never connected by the repeat loop."""
     provider = _create_provider(robot_locator, auto_connect=False)
     assert 'usb-0' in provider.cameras
-    assert provider.auto_connect == {'usb-0': False}
+    assert provider.should_be_connected == {'usb-0': False}
     await forward(provider.RECONNECT_INTERVAL + 1)
     assert not provider.cameras['usb-0'].is_connected
 
 
-async def test_enabling_auto_connect_connects_and_keeps_camera_connected(robot_locator):
-    """Enabling auto-connect connects the camera immediately and the repeat loop keeps it connected."""
+async def test_connecting_a_camera_keeps_it_connected(robot_locator):
+    """Connecting a camera that does not auto-connect makes the repeat loop keep it connected."""
     provider = _create_provider(robot_locator, auto_connect=False)
-    await provider.set_auto_connect('usb-0', True)
-    assert provider.auto_connect['usb-0']
+    await provider.set_connected('usb-0', True)
+    assert provider.should_be_connected['usb-0']
     assert provider.cameras['usb-0'].is_connected
     await forward(provider.RECONNECT_INTERVAL + 1)
     assert provider.cameras['usb-0'].is_connected
 
 
-async def test_disabling_auto_connect_disconnects_camera_for_good(robot_locator):
-    """Disabling auto-connect disconnects the camera and the repeat loop does not reconnect it."""
+async def test_disconnecting_a_camera_keeps_it_disconnected(robot_locator):
+    """Disconnecting a camera stops the repeat loop from reconnecting it, even with auto_connect=True."""
     provider = _create_provider(robot_locator, auto_connect=True)
     await forward(provider.RECONNECT_INTERVAL + 1)
     assert provider.cameras['usb-0'].is_connected
-    await provider.set_auto_connect('usb-0', False)
-    assert not provider.auto_connect['usb-0']
+    await provider.set_connected('usb-0', False)
+    assert not provider.should_be_connected['usb-0']
     assert not provider.cameras['usb-0'].is_connected
     await forward(provider.RECONNECT_INTERVAL + 1)
     assert not provider.cameras['usb-0'].is_connected
@@ -195,7 +195,7 @@ def _create_provider(robot_locator: RobotLocator, *, auto_connect: bool) -> Came
     """Create a provider with a single main camera.
 
     :param robot_locator: Frame provider to link the camera extrinsics to.
-    :param auto_connect: Desired connection state to configure for the camera.
+    :param auto_connect: Whether the camera is configured to connect automatically.
     :return: The camera provider.
     """
     config = CameraConfiguration(

--- a/tests/test_camera_provider.py
+++ b/tests/test_camera_provider.py
@@ -1,5 +1,7 @@
 import pytest
 import rosys
+from nicegui import Client, binding, ui
+from nicegui.page import page
 from rosys.geometry import Rectangle
 from rosys.hardware import WheelsSimulation
 from rosys.testing import forward
@@ -198,12 +200,62 @@ async def test_set_auto_connect_with_unknown_camera_id_raises(robot_locator):
         await provider.set_auto_connect('usb-9', True)
 
 
+async def test_auto_connect_property_returns_a_copy(robot_locator):
+    """The exposed desired-state map must not allow changing a state without connecting or disconnecting."""
+    provider = _create_provider(robot_locator, auto_connect=False)
+    provider.auto_connect['usb-0'] = True
+    assert provider.auto_connect == {'usb-0': False}
+    await forward(provider.RECONNECT_INTERVAL + 1)
+    assert not provider.cameras['usb-0'].is_connected
+
+
+async def test_developer_ui_switch_follows_state_changed_elsewhere(robot_locator):
+    """The switch shows the current desired state even when it is changed outside the UI, e.g. via MCP."""
+    provider = _create_provider(robot_locator, auto_connect=False)
+    with Client(page('/')) as client:
+        provider.developer_ui()
+        switch = _find_switch(client)
+        assert switch.value is False
+        await provider.set_auto_connect('usb-0', True)
+        binding._refresh_step()  # pylint: disable=protected-access
+        assert switch.value is True
+
+
+async def test_developer_ui_switch_notifies_about_a_failing_connect(robot_locator, monkeypatch):
+    """A camera that refuses to connect must tell the operator instead of only writing to the log."""
+    provider = _create_provider(robot_locator, auto_connect=False)
+
+    async def refuse_connection() -> None:
+        raise RuntimeError('device is busy')
+
+    monkeypatch.setattr(provider.cameras['usb-0'], 'connect', refuse_connection)
+    notifications: list[str] = []
+    monkeypatch.setattr(rosys, 'notify', lambda message, *args, **kwargs: notifications.append(message))
+    with Client(page('/')) as client:
+        provider.developer_ui()
+        _find_switch(client).set_value(True)
+        await forward(1)
+    assert notifications == ['Failed to connect camera usb-0: device is busy']
+    assert not provider.cameras['usb-0'].is_connected
+
+
 @pytest.mark.parametrize('auto_connect', [True, False])
 async def test_camera_kwargs_pass_auto_connect_to_rosys(auto_connect: bool):
     """The auto_connect configuration reaches the rosys camera as its connect_after_init argument."""
     config = UsbCameraConfig(camera_id='usb-0', image_size=ImageSize(width=1280, height=720),
                              auto_connect=auto_connect)
     assert config.camera_kwargs['connect_after_init'] is auto_connect
+
+
+def _find_switch(client: Client) -> ui.switch:
+    """Get the single auto-connect switch of a developer UI built into the given client.
+
+    :param client: Client the developer UI was built into.
+    :return: The auto-connect switch.
+    """
+    switches = [element for element in client.elements.values() if isinstance(element, ui.switch)]
+    assert len(switches) == 1
+    return switches[0]
 
 
 def _create_provider(robot_locator: RobotLocator, *, auto_connect: bool) -> CameraProvider:

--- a/tests/test_camera_provider.py
+++ b/tests/test_camera_provider.py
@@ -158,3 +158,65 @@ async def test_cameras_connect_on_update(robot_locator):
     assert not provider.main.is_connected
     await forward(provider.RECONNECT_INTERVAL + 1)
     assert provider.main.is_connected
+
+
+async def test_camera_without_auto_connect_stays_disconnected(robot_locator):
+    """A camera configured with auto_connect=False is created but never connected by the repeat loop."""
+    provider = _create_provider(robot_locator, auto_connect=False)
+    assert 'usb-0' in provider.cameras
+    assert provider.auto_connect == {'usb-0': False}
+    await forward(provider.RECONNECT_INTERVAL + 1)
+    assert not provider.cameras['usb-0'].is_connected
+
+
+async def test_enabling_auto_connect_connects_and_keeps_camera_connected(robot_locator):
+    """Enabling auto-connect connects the camera immediately and the repeat loop keeps it connected."""
+    provider = _create_provider(robot_locator, auto_connect=False)
+    await provider.set_auto_connect('usb-0', True)
+    assert provider.auto_connect['usb-0']
+    assert provider.cameras['usb-0'].is_connected
+    await forward(provider.RECONNECT_INTERVAL + 1)
+    assert provider.cameras['usb-0'].is_connected
+
+
+async def test_disabling_auto_connect_disconnects_camera_for_good(robot_locator):
+    """Disabling auto-connect disconnects the camera and the repeat loop does not reconnect it."""
+    provider = _create_provider(robot_locator, auto_connect=True)
+    await forward(provider.RECONNECT_INTERVAL + 1)
+    assert provider.cameras['usb-0'].is_connected
+    await provider.set_auto_connect('usb-0', False)
+    assert not provider.auto_connect['usb-0']
+    assert not provider.cameras['usb-0'].is_connected
+    await forward(provider.RECONNECT_INTERVAL + 1)
+    assert not provider.cameras['usb-0'].is_connected
+
+
+async def test_set_auto_connect_with_unknown_camera_id_raises(robot_locator):
+    """Setting the desired state of an unconfigured camera reports the available ids."""
+    provider = _create_provider(robot_locator, auto_connect=True)
+    with pytest.raises(ValueError, match='Unknown camera id: usb-9'):
+        await provider.set_auto_connect('usb-9', True)
+
+
+@pytest.mark.parametrize('auto_connect', [True, False])
+async def test_camera_kwargs_pass_auto_connect_to_rosys(auto_connect: bool):
+    """The auto_connect configuration reaches the rosys camera as its connect_after_init argument."""
+    config = UsbCameraConfig(camera_id='usb-0', image_size=ImageSize(width=1280, height=720),
+                             auto_connect=auto_connect)
+    assert config.camera_kwargs['connect_after_init'] is auto_connect
+
+
+def _create_provider(robot_locator: RobotLocator, *, auto_connect: bool) -> CameraProvider:
+    """Create a provider with a single main camera.
+
+    :param robot_locator: Frame provider to link the camera extrinsics to.
+    :param auto_connect: Desired connection state to configure for the camera.
+    :return: The camera provider.
+    """
+    config = CameraConfiguration(
+        main=UsbCameraConfig(camera_id='usb-0', image_size=ImageSize(width=1280, height=720),
+                             auto_connect=auto_connect),
+        front=None,
+        back=None,
+    )
+    return CameraProvider(config, frame_provider=robot_locator)


### PR DESCRIPTION
### Motivation

Every configured camera is connected automatically — by rosys on startup and again by the reconnect loop of `CameraProvider`. Some cameras should stay off until they are actually needed, and it should be possible to connect and disconnect a camera while the robot is running.

### Implementation

- Extend `CameraSlotConfig` with an `auto_connect` field and pass it to rosys as `connect_after_init` (also for `SimulatedCalibratableCamera`, so simulation matches hardware)
- Track per camera whether it should be connected, readable as a copy via `should_be_connected` and changed with `set_connected(camera_id, connected)`, which connects/disconnects right away
- Let `update_device_list` connect only cameras that should be connected, so a disconnect sticks
- Put a compact icon button next to the connection bulb in the camera developer UI: the icon shows the action it offers (`link`/`link_off`), so a "Disconnect" button on a grey bulb means the connection is failing. A failing connect is reported with `rosys.notify`

The state is runtime-only and not persisted: after a restart the configuration applies again.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] I documented breaking changes and set the 'breaking change' label if needed
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

---
⬛ claude-opus-5 (1M context)