### PR TITLE
Fix the endless advance loop when the robot is at the segment end

### DIFF
--- a/feldfreund_devkit/navigation/waypoint_navigation.py
+++ b/feldfreund_devkit/navigation/waypoint_navigation.py
@@ -195,7 +195,6 @@ class WaypointNavigation(rosys.persistence.Persistable):
             return True
         if target_t < current_t or target_t > 1.0:
             # TODO: we need a sturdy function to advance a certain distance on a spline, because this method is off by a tiny amount. That's why +0.00003
-            # test_weeding.py::test_advance_when_target_behind_robot tests this case. The weed is skipped in this case
             if current_t >= 1.0:
                 return True
             advance_distance = self.driver.parameters.minimum_drive_distance

--- a/feldfreund_devkit/navigation/waypoint_navigation.py
+++ b/feldfreund_devkit/navigation/waypoint_navigation.py
@@ -196,10 +196,12 @@ class WaypointNavigation(rosys.persistence.Persistable):
         if target_t < current_t or target_t > 1.0:
             # TODO: we need a sturdy function to advance a certain distance on a spline, because this method is off by a tiny amount. That's why +0.00003
             # test_weeding.py::test_advance_when_target_behind_robot tests this case. The weed is skipped in this case
+            if current_t >= 1.0:
+                return True
             advance_distance = self.driver.parameters.minimum_drive_distance
             while True:
                 target_pose = current_pose + PoseStep(linear=advance_distance, angular=0.0, time=0.0)
-                target_t = spline.closest_point(target_pose.x, target_pose.y)
+                target_t = spline.closest_point(target_pose.x, target_pose.y, t_min=-0.2, t_max=1.2)
                 advance_spline = sub_spline(spline, current_t, target_t)
                 if advance_spline.estimated_length() > self.driver.parameters.minimum_drive_distance:
                     break


### PR DESCRIPTION
### Motivation

`_follow_segment_until` can spin forever. The advance loop at `waypoint_navigation.py:200` calls `spline.closest_point` with **default** bounds, unlike the two calls just above it at `:191` and `:196` which pass `t_min=-0.2, t_max=1.2`. The defaults clamp to `[0, 1]`, so once the robot reaches the end of the segment `target_t` saturates at `1.0`, the advance sub-spline stops growing, `estimated_length()` never exceeds `minimum_drive_distance`, and the only `break` becomes unreachable.

There is no `await` in the loop body, so this does not merely spin — it blocks the whole asyncio loop.

![before and after](https://raw.githubusercontent.com/evnchn/feldfreund_devkit/pr-assets/waypoint_loop_before_after.png)

Swept over 66 robot positions along a 2 m segment against real `rosys.geometry` and this repo's own `sub_spline`. Normal positions behave identically before and after (1–2 iterations); only the hang region changes.

Not reachable with the shipped `ImplementDummy` — its `get_target()` returns `None`. It needs a `use_implement=True` segment with an `Implement` that returns a target, so it bites devkit consumers rather than the stock demo.

### Implementation

Two changes, both in the same block:

1. Pass the extended `t_min`/`t_max` bounds inside the loop, matching `:191` and `:196`.
2. Return early when `current_t >= 1.0`.

**The second is not redundant, and this is the part worth reviewing.** My first attempt was the one-line bounds fix alone. It is insufficient:

```
extended-bounds only:
  robot_x=1.99   BROKE after 2 iters  target_t=1.0033
  robot_x=1.995  BROKE after 2 iters  target_t=1.0050
  robot_x=2.0    *** NO BREAK after 20,000 iters *** (current_t=1.0000 target_t=1.0684 len=1.33e-15)
  robot_x=2.05   *** NO BREAK after 20,000 iters *** (current_t=1.0000 target_t=1.0828 len=1.33e-15)
```

Once `current_t` is exactly `1.0`, `sub_spline(spline, 1.0, 1.068)` is degenerate — length `1.33e-15` — however far `target_t` extends. A bounds-only patch would still hang.

`return True` for "robot is at or past the segment end" is my reading, chosen to match the existing early return at `:193` (`if abs(distance_to_target) < minimum_drive_distance: return True`) and this block's own comment that the weed is skipped in that case. **If you would rather it returned `False`, or skipped differently, say so** — I fixed the hang without trying to settle the geometry question. The block's `TODO` ("we need a sturdy function to advance a certain distance on a spline") suggests you already consider it provisional.

<details>
<summary>Standalone repro (no hardware, no test-suite changes)</summary>

```bash
pip install rosys==0.34.0
cd <feldfreund_devkit checkout> && pip install -e .
python3 mre_waypoint_loop.py          # as shipped -> AssertionError
python3 mre_waypoint_loop.py --fixed  # with this PR -> exit 0
```

```python
"""_follow_segment_until never terminates when the robot is at or past the segment end."""
import itertools, sys
from rosys.geometry import Pose, PoseStep, Spline
from feldfreund_devkit.navigation.utils import sub_spline

MINIMUM_DRIVE_DISTANCE = 0.02          # rosys DriveParameters default
ITER_CAP = 20_000                      # only so this repro terminates; upstream has no cap
FIXED = '--fixed' in sys.argv


def advance_loop(robot_x: float) -> int | None:
    spline = Spline.from_poses(Pose(x=0, y=0, yaw=0), Pose(x=2, y=0, yaw=0))
    current_pose = Pose(x=robot_x, y=0, yaw=0)
    current_t = spline.closest_point(current_pose.x, current_pose.y)
    if FIXED and current_t >= 1.0:
        return 0
    advance_distance = MINIMUM_DRIVE_DISTANCE
    for i in itertools.count(1):
        target_pose = current_pose + PoseStep(linear=advance_distance, angular=0.0, time=0.0)
        target_t = (spline.closest_point(target_pose.x, target_pose.y, t_min=-0.2, t_max=1.2) if FIXED
                    else spline.closest_point(target_pose.x, target_pose.y))
        if sub_spline(spline, current_t, target_t).estimated_length() > MINIMUM_DRIVE_DISTANCE:
            return i
        advance_distance += 0.00001
        if i >= ITER_CAP:
            return None


for robot_x in (1.5, 1.9, 1.99, 2.0, 2.05):
    n = advance_loop(robot_x)
    print(f'robot_x={robot_x:<5} -> ' + ('NEVER BREAKS' if n is None else
                                         'returns immediately' if n == 0 else f'breaks after {n}'))

assert advance_loop(2.0) is not None, 'never breaks with the robot at the segment end'
```

Docker `python:3.12`, Python 3.12.13, rosys 0.34.0, linux aarch64:

```
AS SHIPPED                              FIXED
robot_x=1.5   -> breaks after 2         robot_x=1.5   -> breaks after 2
robot_x=1.9   -> breaks after 1         robot_x=1.9   -> breaks after 1
robot_x=1.99  -> NEVER BREAKS           robot_x=1.99  -> breaks after 2
robot_x=2.0   -> NEVER BREAKS           robot_x=2.0   -> returns immediately
robot_x=2.05  -> NEVER BREAKS           robot_x=2.05  -> returns immediately
AssertionError / EXIT=1                 EXIT=0
```
</details>

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] I documented breaking changes and set the 'breaking change' label if needed — none; only previously-hanging inputs change behaviour
- [x] The implementation is complete.
- [ ] Tests with a real hardware have been successful (or are not necessary) — **not run.** No hardware; verified against real `rosys.geometry` and the repo's own `sub_spline` only.
- [ ] Pytests have been added (or are not necessary) — **deliberately not added.** A direct regression test would *hang the suite* without the fix rather than fail: the loop contains no `await`, so `asyncio.wait_for` cannot interrupt it, and `pytest-timeout` is not in the dev dependencies. Happy to add one if you want that dependency; the standalone repro above covers it meanwhile.
- [x] Documentation has been added (or is not necessary) — not necessary.
