### PR TITLE
Allow single bumpers to be None

### DIFF
--- a/feldfreund_devkit/config/bumper_configuration.py
+++ b/feldfreund_devkit/config/bumper_configuration.py
@@ -9,16 +9,17 @@ class BumperConfiguration:
         name: 'bumper'
         on_expander: True
     """
-    pin_front_top: int
-    pin_front_bottom: int
-    pin_back: int
+    pin_front_top: int | None
+    pin_front_bottom: int | None
+    pin_back: int | None
     name: str = 'bumper'
     on_expander: bool = True
 
     @property
     def pins(self) -> dict[str, int]:
-        return {
+        pins = {
             'front_top': self.pin_front_top,
             'front_bottom': self.pin_front_bottom,
-            'back': self.pin_back
+            'back': self.pin_back,
         }
+        return {name: pin for name, pin in pins.items() if pin is not None}


### PR DESCRIPTION
### Motivation

`BumperConfiguration` demanded all three pins, so a robot without a back bumper or without the second front switch had no way to be configured. `Safety` already builds its Lizard conditions from whatever `bumper.pins` contains, so a subset works everywhere downstream.

### Implementation

- Widen `pin_front_top`, `pin_front_bottom` and `pin_back` to `int | None`
- Drop the unset ones in the `pins` property, so only the bumpers a robot actually has are registered

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] I documented breaking changes and set the 'breaking change' label if needed
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

⬛ claude-opus-5 (1M context)
