### PR TITLE
Run mkdocs through uv in the docs job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --group docs
       - name: Build docs
-        run: mkdocs build -v
+        run: uv run mkdocs build -v
       - name: Deploy gh-pages
         uses: JamesIves/github-pages-deploy-action@v4.7.3
         with:


### PR DESCRIPTION
### Motivation

The `docs` job builds with a bare `mkdocs build -v`, which has never resolved: `uv sync --group docs` installs mkdocs into the project venv, and nothing puts that venv on the runner's PATH. The call has been there since the job was added in #3, but the job hung on `needs: pypi`, and `pypi` fails on every tag at the PyPI direct-dependency blocker (`rosys @ git+…`), so the docs job was skipped rather than run — at v0.2.0 it is recorded as `skipped`. #65 moved it behind `test`, and at v0.3.0 it executed for the first time and died with `mkdocs: command not found` ([run](https://github.com/zauberzeug/feldfreund_devkit/actions/runs/32516661739)). The v0.2.0 and v0.3.0 docs had to be deployed manually.

Note that `pypi` stays red on tags regardless of this PR.

### Implementation

- Run the build step as `uv run mkdocs build -v`

<details>
<summary>Why <code>uv run</code> does not evict the docs group</summary>

`docs` is not in `default-groups = ["dev", "test"]`, and `uv run` syncs the environment before executing — so it could in principle undo the `uv sync --group docs` above it. It does not: `uv run` syncs inexactly, `--exact` ("perform an exact sync, removing extraneous packages") is opt-in. Reproduced at this PR's head with `UV_NO_SOURCES=true`: the bare call exits 127, `uv run mkdocs build -v` exits 0 and builds 64 files.

</details>

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] I documented breaking changes and set the 'breaking change' label if needed
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

⬛ claude-fable-5
